### PR TITLE
feat: automate version bumping via GitHub Actions

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,79 @@
+name: Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@1edb52594c857e2b5b13128931090f0640537287  # v1
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Determine bump type from labels
+        id: bump-type
+        run: |
+          LABELS='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$LABELS" | grep -q "bump:major"; then
+            echo "type=major" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q "bump:minor"; then
+            echo "type=minor" >> $GITHUB_OUTPUT
+          elif echo "$LABELS" | grep -q "bump:patch"; then
+            echo "type=patch" >> $GITHUB_OUTPUT
+          else
+            echo "type=none" >> $GITHUB_OUTPUT
+          fi
+          echo "Detected bump type: $(cat $GITHUB_OUTPUT)"
+
+      - name: Install dependencies
+        if: steps.bump-type.outputs.type != 'none'
+        run: uv sync --all-groups
+
+      - name: Bump version
+        if: steps.bump-type.outputs.type != 'none'
+        run: |
+          uv run bump-my-version bump ${{ steps.bump-type.outputs.type }}
+          NEW_VERSION=$(uv run bump-my-version show current_version)
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_ENV
+
+      - name: Push changes and tags
+        if: steps.bump-type.outputs.type != 'none'
+        run: |
+          git push origin main --tags
+
+      - name: Create GitHub Release
+        if: steps.bump-type.outputs.type != 'none'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${NEW_VERSION}" \
+            --title "Release v${NEW_VERSION}" \
+            --generate-notes
+
+      - name: Skip message
+        if: steps.bump-type.outputs.type == 'none'
+        run: |
+          echo "No version bump label found (bump:major, bump:minor, or bump:patch)"
+          echo "Skipping version bump"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install lint-fix test pre-commit bump-patch bump-minor bump-major clean
+.PHONY: install lint-fix test pre-commit clean
 
 install:
 	uv sync --all-groups
@@ -16,15 +16,6 @@ test:
 
 pre-commit:
 	uv run pre-commit run --all-files
-
-bump-patch:
-	uv run bump-my-version bump patch
-
-bump-minor:
-	uv run bump-my-version bump minor
-
-bump-major:
-	uv run bump-my-version bump major
 
 clean:
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/README.md
+++ b/README.md
@@ -395,7 +395,6 @@ make install      # Install dependencies + pre-commit hooks
 make lint-fix     # Format and lint code
 make test         # Run tests
 make pre-commit   # Run pre-commit on all files
-make bump-patch   # Bump version (0.1.0 → 0.1.1)
 make clean        # Remove cache/build artifacts
 ```
 


### PR DESCRIPTION
## Summary by Sourcery

Automate the project’s version bumping and release process via a GitHub Actions workflow and remove the corresponding manual Makefile targets.

New Features:
- Add a GitHub Actions workflow to detect bump:major/minor/patch labels on merged PRs, run version bump, push tags, and create GitHub releases

Enhancements:
- Remove bump-patch, bump-minor, and bump-major targets from the Makefile to eliminate manual version bumping

CI:
- Introduce version-bump.yml workflow that configures git, determines bump type from labels, installs dependencies, and automates version update and release creation

Documentation:
- Remove the manual bump-patch instruction from the README