### PR TITLE
fix: add write permissions to version bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -9,6 +9,9 @@ jobs:
   bump:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Fixes 403 permission error by adding explicit write permissions to workflow.

## Summary by Sourcery

Grant explicit write permissions for contents and pull-requests in the version bump workflow to resolve 403 permission errors

Bug Fixes:
- Fix 403 permission error in version bump workflow by granting write permissions

CI:
- Add contents: write and pull-requests: write permissions to version-bump GitHub Actions workflow