### PR TITLE
fix: add missing injected params to EditMemoryFileInput

### DIFF
--- a/src/tools/internal/memory.py
+++ b/src/tools/internal/memory.py
@@ -7,6 +7,7 @@ enabling context offloading and information persistence across agent interaction
 from typing import Annotated
 
 from langchain_core.messages import ToolMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import InjectedToolCallId, ToolException, tool
 from langgraph.prebuilt import InjectedState
 from langgraph.types import Command
@@ -26,6 +27,8 @@ class EditOperation(BaseModel):
 class EditMemoryFileInput(BaseModel):
     """Input schema for edit_memory_file."""
 
+    config: RunnableConfig
+    tool_call_id: Annotated[str, InjectedToolCallId]
     file_path: str = Field(..., description="Path to the memory file to edit")
     edits: list[EditOperation] = Field(
         ..., description="List of edit operations to apply sequentially"

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,7 @@ wheels = [
 
 [[package]]
 name = "langrepl"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Fixes schema validation for edit_memory_file tool.

## Summary by Sourcery

Add missing injected parameters to the EditMemoryFileInput schema and update lockfile

Bug Fixes:
- Add config and tool_call_id fields to EditMemoryFileInput to fix schema validation for the edit_memory_file tool

Build:
- Regenerate uv.lock after schema updates