### PR TITLE
refactor: standardize key bindings to use Keys enum constants

### DIFF
--- a/src/cli/interface/prompt.py
+++ b/src/cli/interface/prompt.py
@@ -118,7 +118,7 @@ class InteractivePrompt:
         """Create custom key bindings."""
         kb = KeyBindings()
 
-        @kb.add("c-c")
+        @kb.add(Keys.ControlC)
         def _(event):
             """Ctrl-C: Clear input if text exists, or quit on double-press."""
             buffer = event.current_buffer
@@ -149,10 +149,10 @@ class InteractivePrompt:
 
         @kb.add(Keys.ControlJ)
         def _(event):
-            """Shift+Enter: Insert newline for multiline input."""
+            """Ctrl-J: Insert newline for multiline input."""
             event.current_buffer.insert_text("\n")
 
-        @kb.add("s-tab")
+        @kb.add(Keys.BackTab)
         def _(event):
             """Shift-Tab: Cycle approval mode."""
             if self.mode_change_callback:

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,7 @@ wheels = [
 
 [[package]]
 name = "langrepl"
-version = "0.2.2"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Replace string literals ("c-c", "s-tab") with Keys enum constants (ControlC, BackTab) for better type safety and consistency
- Fix incorrect docstring: Ctrl-J instead of Shift+Enter

## Test plan
- [x] Pre-commit hooks passed
- [x] Manual testing: verify Ctrl-C, Ctrl-J, and Shift-Tab still work as expected in the CLI

## Summary by Sourcery

Refactor key bindings to use Keys enum constants and correct the Ctrl-J docstring

Enhancements:
- Replace string literal key bindings with Keys.ControlC and Keys.BackTab for improved type safety and consistency
- Fix docstring for Keys.ControlJ to accurately describe the Ctrl-J action