### PR TITLE
feat: add @ reference completion for file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ https://github.com/user-attachments/assets/5d95e221-3883-44f8-9694-74c5e215b4e2
     - Ubuntu/Debian: `sudo apt install ripgrep`
     - Arch Linux: `sudo pacman -S ripgrep`
     - Windows: `choco install ripgrep` or download from [releases](https://github.com/BurntSushi/ripgrep/releases)
+- **fd** - Fast file finder used for file/directory completion (fallback when not in a Git repository):
+    - macOS: `brew install fd`
+    - Ubuntu/Debian: `sudo apt install fd-find`
+    - Arch Linux: `sudo pacman -S fd`
+    - Windows: `choco install fd` or download from [releases](https://github.com/sharkdp/fd/releases)
 - **Node.js & npm** (optional) - Required only if using MCP servers that run via npx
 
 ## Installation

--- a/src/cli/core/session.py
+++ b/src/cli/core/session.py
@@ -66,18 +66,18 @@ class CLISession:
 
         while self.running:
             try:
-                user_input = await self.prompt.get_input()
+                content, short_content, is_slash_command = await self.prompt.get_input()
 
-                if not user_input or not user_input.strip():
+                if not content or not content.strip():
                     continue
 
-                if user_input.startswith("/"):
-                    result = await self.command_handler.handle(user_input)
+                if is_slash_command:
+                    result = await self.command_handler.handle(content)
                     if result:
                         self.prefilled_text = result
                     continue
 
-                await self.message_handler.handle(user_input)
+                await self.message_handler.handle(content, short_content)
 
             except EOFError:
                 break

--- a/src/cli/interface/completers/__init__.py
+++ b/src/cli/interface/completers/__init__.py
@@ -1,0 +1,7 @@
+"""Completers for CLI prompt input."""
+
+from src.cli.interface.completers.reference import ReferenceCompleter
+from src.cli.interface.completers.router import CompleterRouter
+from src.cli.interface.completers.slash import SlashCommandCompleter
+
+__all__ = ["CompleterRouter", "ReferenceCompleter", "SlashCommandCompleter"]

--- a/src/cli/interface/completers/reference.py
+++ b/src/cli/interface/completers/reference.py
@@ -1,0 +1,123 @@
+"""Reference completer for @ references."""
+
+import re
+from collections.abc import AsyncGenerator, Iterable
+from pathlib import Path
+
+from prompt_toolkit.completion import CompleteEvent, Completer, Completion
+from prompt_toolkit.document import Document
+
+from src.cli.interface.resolvers import RefType
+from src.cli.interface.resolvers.file import FileResolver
+
+
+def parse_reference(ref: str) -> tuple[RefType | None, str]:
+    """Parse typed reference into type and value.
+
+    Args:
+        ref: Reference string (e.g., "@:file:path" or ":file:path" or "path")
+
+    Returns:
+        Tuple of (RefType, value) or (None, original) if no type prefix
+    """
+    content = ref.lstrip("@")
+
+    if content.startswith(":"):
+        parts = content[1:].split(":", 1)
+        if len(parts) == 2:
+            type_str, value = parts
+            try:
+                return RefType(type_str), value
+            except ValueError:
+                pass
+
+    return None, content
+
+
+class ReferenceCompleter(Completer):
+    """Completer for @ references."""
+
+    def __init__(
+        self,
+        working_dir: Path,
+        max_suggestions: int = 10,
+    ):
+        """Initialize reference completer."""
+        self.max_suggestions = max_suggestions
+        self.working_dir = working_dir
+
+        self.resolvers = {
+            RefType.FILE: FileResolver(),
+        }
+
+    def get_completions(
+        self, document: Document, complete_event: CompleteEvent
+    ) -> Iterable[Completion]:
+        """Sync stub - completions are async only."""
+        return iter([])
+
+    async def get_completions_async(
+        self, document: Document, complete_event: CompleteEvent
+    ) -> AsyncGenerator[Completion]:
+        """Get completions asynchronously."""
+        text = document.text_before_cursor
+
+        if at_match := self._find_at_ref(text):
+            async for completion in self._complete_ref(at_match.group(1), document):
+                yield completion
+
+    @staticmethod
+    def _find_at_ref(text: str) -> re.Match[str] | None:
+        """Find last @ reference before cursor."""
+        pattern = r"@([^\s]*)$"
+        return re.search(pattern, text)
+
+    async def _complete_ref(
+        self, fragment: str, document: Document
+    ) -> AsyncGenerator[Completion]:
+        """Get reference completions."""
+        text_before = document.text_before_cursor
+        at_pos = text_before.rfind("@")
+        start_position = at_pos - len(text_before)
+
+        ctx = {"start_position": start_position, "working_dir": str(self.working_dir)}
+
+        completions: list[Completion] = []
+        type_filter, ref_fragment = parse_reference(fragment)
+        if type_filter and (resolver := self.resolvers.get(type_filter, None)):
+            completions = await resolver.complete(
+                ref_fragment, ctx, self.max_suggestions
+            )
+        else:
+            for resolver in self.resolvers.values():
+                result = await resolver.complete(
+                    ref_fragment, ctx, self.max_suggestions - len(completions)
+                )
+                completions.extend(result)
+                if len(completions) >= self.max_suggestions:
+                    break
+
+        for completion in completions:
+            yield completion
+
+    def resolve_refs(self, text: str) -> str:
+        """Resolve @ references in text to absolute paths.
+
+        Args:
+            text: Text containing @:type:value references
+
+        Returns:
+            Text with references resolved to absolute paths
+        """
+        if "@:" not in text:
+            return text
+
+        ctx = {"working_dir": str(self.working_dir)}
+
+        def resolve(m):
+            type_filter, ref_value = parse_reference(f":{m.group(1)}:{m.group(2)}")
+            if type_filter and (resolver := self.resolvers.get(type_filter, None)):
+                return resolver.resolve(ref_value, ctx)
+            return m.group(0)
+
+        return re.sub(r"@:(\w+):(\S+)", resolve, text)

--- a/src/cli/interface/completers/router.py
+++ b/src/cli/interface/completers/router.py
@@ -1,0 +1,51 @@
+"""Completer router for slash commands and references."""
+
+from collections.abc import AsyncGenerator, Iterable
+from pathlib import Path
+
+from prompt_toolkit.completion import CompleteEvent, Completer, Completion
+from prompt_toolkit.document import Document
+
+from src.cli.interface.completers.reference import ReferenceCompleter
+from src.cli.interface.completers.slash import SlashCommandCompleter
+
+
+class CompleterRouter(Completer):
+    """Routes completions to slash command or reference completers."""
+
+    def __init__(
+        self,
+        commands: list[str],
+        working_dir: Path,
+        max_suggestions: int = 10,
+    ):
+        """Initialize completer router."""
+        self.slash_completer = SlashCommandCompleter(commands)
+        self.reference_completer = ReferenceCompleter(working_dir, max_suggestions)
+
+    def get_completions(
+        self, document: Document, complete_event: CompleteEvent
+    ) -> Iterable[Completion]:
+        """Sync stub - completions are async only."""
+        return iter([])
+
+    async def get_completions_async(
+        self, document: Document, complete_event: CompleteEvent
+    ) -> AsyncGenerator[Completion]:
+        """Get completions asynchronously."""
+        text = document.text_before_cursor
+
+        if text.lstrip().startswith("/"):
+            for completion in self.slash_completer.get_completions(
+                document, complete_event
+            ):
+                yield completion
+        else:
+            async for completion in self.reference_completer.get_completions_async(
+                document, complete_event
+            ):
+                yield completion
+
+    def resolve_refs(self, text: str) -> str:
+        """Resolve @ references in text to absolute paths."""
+        return self.reference_completer.resolve_refs(text)

--- a/src/cli/interface/completers/slash.py
+++ b/src/cli/interface/completers/slash.py
@@ -1,0 +1,19 @@
+"""Slash command completer."""
+
+from collections.abc import Iterable
+
+from prompt_toolkit.completion import CompleteEvent, Completion, WordCompleter
+from prompt_toolkit.document import Document
+
+
+class SlashCommandCompleter(WordCompleter):
+    """Auto-completer for slash commands."""
+
+    def __init__(self, commands: list[str]):
+        super().__init__(commands, ignore_case=True, sentence=True)
+
+    def get_completions(
+        self, document: Document, complete_event: CompleteEvent
+    ) -> Iterable[Completion]:
+        """Get completions for slash commands."""
+        yield from super().get_completions(document, complete_event)

--- a/src/cli/interface/messages.py
+++ b/src/cli/interface/messages.py
@@ -24,11 +24,11 @@ class MessageHandler:
         self.session = session
         self.interrupt_handler = InterruptHandler()
 
-    async def handle(self, content: str) -> None:
+    async def handle(self, content: str, short_content: str) -> None:
         """Handle user message and get AI response."""
         try:
             # Create a human message
-            human_message = HumanMessage(content=content)
+            human_message = HumanMessage(content=content, short_content=short_content)
 
             # Prepare graph config
             ctx = self.session.context

--- a/src/cli/interface/prompt.py
+++ b/src/cli/interface/prompt.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import os
+import re
 import time
 from pathlib import Path
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
-from prompt_toolkit.completion import CompleteEvent, WordCompleter
+from prompt_toolkit.filters import completion_is_selected
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
@@ -17,22 +18,12 @@ from prompt_toolkit.styles import Style
 from prompt_toolkit.validation import Validator
 
 from src.cli.core.context import Context
+from src.cli.interface.completers import CompleterRouter
 from src.cli.theme import theme
 from src.core.config import ApprovalMode
 from src.core.constants import CONFIG_HISTORY_FILE_NAME
 from src.core.settings import settings
 from src.utils.cost import calculate_context_percentage, format_cost, format_tokens
-
-
-class SlashCommandCompleter(WordCompleter):
-    """Auto-completer for slash commands."""
-
-    def __init__(self, commands: list[str]):
-        super().__init__(commands, ignore_case=True, sentence=True)
-
-    def get_completions(self, document, complete_event: CompleteEvent):
-        # Let WordCompleter handle all the filtering naturally
-        yield from super().get_completions(document, complete_event)
 
 
 class MultilineValidator(Validator):
@@ -74,10 +65,12 @@ class InteractivePrompt:
         history_file.parent.mkdir(parents=True, exist_ok=True)
         self.history = FileHistory(str(history_file))
         self.session: PromptSession[str]
+        self.completer: CompleterRouter
         self.mode_change_callback = None
         self._last_ctrl_c_time: float | None = None
         self._ctrl_c_timeout = 0.5  # 500ms window for double-press detection
         self._show_quit_message = False
+        self._reference_mapping: dict[str, str] = {}
         self._setup_session()
 
     def _setup_session(self) -> None:
@@ -88,8 +81,12 @@ class InteractivePrompt:
         # Create style
         style = self._create_style()
 
-        # Create completer
-        completer = SlashCommandCompleter(self.commands)
+        # Create completer router for slash commands and @ references
+        self.completer = CompleterRouter(
+            commands=self.commands,
+            working_dir=Path(self.context.working_dir),
+            max_suggestions=settings.cli.max_autocomplete_suggestions,
+        )
 
         # Create validator
         validator = MultilineValidator(settings.cli.multiline_threshold)
@@ -98,7 +95,7 @@ class InteractivePrompt:
         self.session = PromptSession(
             history=self.history,
             auto_suggest=AutoSuggestFromHistory(),
-            completer=completer,
+            completer=self.completer,
             complete_style=CompleteStyle.COLUMN,
             key_bindings=kb,
             style=style,
@@ -110,6 +107,7 @@ class InteractivePrompt:
             wrap_lines=settings.cli.enable_word_wrap,
             mouse_support=False,
             complete_while_typing=True,
+            complete_in_thread=False,
             placeholder=self._get_placeholder,
             bottom_toolbar=self._get_bottom_toolbar,
         )
@@ -157,6 +155,23 @@ class InteractivePrompt:
             """Shift-Tab: Cycle approval mode."""
             if self.mode_change_callback:
                 self.mode_change_callback()
+
+        @kb.add(Keys.Enter, filter=completion_is_selected)
+        def _(event):
+            """Enter when completion is selected: apply completion."""
+            buffer = event.current_buffer
+            if buffer.complete_state:
+                current_completion = buffer.complete_state.current_completion
+                buffer.apply_completion(current_completion)
+
+                # For slash commands, submit immediately
+                if buffer.text.lstrip().startswith("/"):
+                    buffer.validate_and_handle()
+                # For @ references, add space and resolve
+                else:
+                    buffer.insert_text(" ")
+                    resolved_reference = self.completer.resolve_refs(buffer.text)
+                    self._reference_mapping[buffer.text] = resolved_reference
 
         return kb
 
@@ -270,6 +285,9 @@ class InteractivePrompt:
                 "completion-menu.meta.completion.current": f"{theme.primary_text} bg:{theme.prompt_color}",
                 # Thread completion styling
                 "thread-completion": f"{theme.accent_color} bg:{theme.background_light}",
+                # File/directory completion styling
+                "file-completion": f"{theme.primary_text} bg:{theme.background_light}",
+                "dir-completion": f"{theme.info_color} bg:{theme.background_light}",
                 # Auto-suggestion styling
                 "auto-suggestion": f"{theme.muted_text} italic",
                 # Validation styling
@@ -291,7 +309,7 @@ class InteractivePrompt:
             }
         )
 
-    async def get_input(self) -> str:
+    async def get_input(self) -> tuple[str, str, bool]:
         """Get user input asynchronously."""
         try:
             prompt_text = [
@@ -306,7 +324,14 @@ class InteractivePrompt:
 
             result = await self.session.prompt_async(prompt_text, default=default_text)  # type: ignore
             print()
-            return result.strip()
+
+            content = result.strip()
+            resolved_content = content
+            for ref, resolved in self._reference_mapping.items():
+                pattern = re.escape(ref)
+                resolved_content = re.sub(pattern, resolved, resolved_content)
+            self._reference_mapping.clear()
+            return content, resolved_content, content.startswith("/")
 
         except (KeyboardInterrupt, EOFError):
             raise

--- a/src/cli/interface/renderer.py
+++ b/src/cli/interface/renderer.py
@@ -83,7 +83,8 @@ class Renderer:
     @staticmethod
     def render_user_message(message: HumanMessage) -> None:
         """Render user message."""
-        console.print(f"[prompt]{settings.cli.prompt_style}[/prompt]{message.text}")
+        content = getattr(message, "short_content", None) or message.text
+        console.print(f"[prompt]{settings.cli.prompt_style}[/prompt]{content}")
         console.print("")
 
     @staticmethod

--- a/src/cli/interface/resolvers/__init__.py
+++ b/src/cli/interface/resolvers/__init__.py
@@ -1,0 +1,5 @@
+"""Reference resolvers for @ syntax."""
+
+from src.cli.interface.resolvers.base import RefType, Resolver
+
+__all__ = ["RefType", "Resolver"]

--- a/src/cli/interface/resolvers/base.py
+++ b/src/cli/interface/resolvers/base.py
@@ -1,0 +1,26 @@
+"""Base classes for reference resolvers."""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+from prompt_toolkit.completion import Completion
+
+
+class RefType(str, Enum):
+    """Reference types."""
+
+    FILE = "file"
+
+
+class Resolver(ABC):
+    """Abstract base for reference resolvers."""
+
+    type: RefType
+
+    @abstractmethod
+    def resolve(self, ref: str, ctx: dict) -> str:
+        """Resolve reference to final value."""
+
+    @abstractmethod
+    async def complete(self, fragment: str, ctx: dict, limit: int) -> list[Completion]:
+        """Get completions for fragment."""

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -96,6 +96,11 @@ class CLISettings(BaseModel):
         default="nano", description="Default text editor for /memory command"
     )
 
+    # Autocomplete settings
+    max_autocomplete_suggestions: int = Field(
+        default=10, description="Maximum number of autocomplete suggestions to show"
+    )
+
 
 class ServerSettings(BaseModel):
     """LangGraph server settings."""


### PR DESCRIPTION
CompleterRouter routes to SlashCommandCompleter and ReferenceCompleter. FileResolver uses git ls-files with fd fallback.

## Summary by Sourcery

Add support for @ reference completion of file and directory paths in the CLI, backed by a new resolver system and routed through a unified completer, with settings and documentation updates

New Features:
- Add @-prefixed reference completion for file and directory paths via ReferenceCompleter and FileResolver
- Introduce CompleterRouter to delegate between slash command and reference completion
- Modify prompt session to return both raw and resolved input, and handle completions differently for slash commands and @ references
- Add CLI setting for max_autocomplete_suggestions

Enhancements:
- Apply distinct styling for file and directory completions
- Use git ls-files with fd fallback in FileResolver to retrieve tracked files and directories

Documentation:
- Update README with fd installation instructions for file/directory completion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified autocomplete router: supports slash-command completion and @-reference file/directory suggestions with distinct styling and immediate submit/insert behavior.
  * Reference resolution: inserted @-references are resolved and substituted in the final input.
  * Prompt input now returns original, resolved content, and a flag for slash commands.
  * Configurable max autocomplete suggestions.

* **Documentation**
  * README: added fd as a fallback file-finder with platform-specific install instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->