### PR TITLE
feat: show tool calls during interrupts with position counts

### DIFF
--- a/src/cli/handlers/interrupts.py
+++ b/src/cli/handlers/interrupts.py
@@ -55,8 +55,7 @@ class InterruptHandler:
             console.print_error(f"Error handling interrupt: {e}")
             return None
 
-    @staticmethod
-    async def _get_choice(interrupt: Interrupt) -> str | None:
+    async def _get_choice(self, interrupt: Interrupt) -> str | None:
         """Choice selector with tab completion and Enter key support."""
         value: InterruptPayload = interrupt.value
         question = value.question
@@ -66,11 +65,8 @@ class InterruptHandler:
         with console.capture() as capture:
             console.print(f"[accent]{question}[/accent]")
         rendered_text = capture.get()
-        # Count actual newlines in the rendered output (not stripping)
-        # This gives us the exact number of line breaks
         lines_to_clear = rendered_text.count("\n")
 
-        # Now print for real
         console.print(f"[accent]{question}[/accent]")
         completer = WordCompleter(options, ignore_case=True)
 

--- a/src/utils/rate_limiter.py
+++ b/src/utils/rate_limiter.py
@@ -1,5 +1,6 @@
 """Rate limiter utilities for API providers with token-based limits."""
 
+import asyncio
 import threading
 import time
 from collections import deque
@@ -209,8 +210,6 @@ class TokenBucketLimiter(BaseRateLimiter):
         if not blocking:
             return self._consume()
 
-        import asyncio
-
         while not self._consume():
             await asyncio.sleep(self.check_every_n_seconds)
         return True
@@ -256,9 +255,6 @@ class TokenBucketLimiter(BaseRateLimiter):
         # Estimate input tokens
         input_text = "\n".join([str(msg.content) for msg in messages])
         estimated_input_tokens = len(input_text) // 4
-
-        # Wait for tokens to be available
-        import asyncio
 
         if estimated_input_tokens > 0:
             # Use the blocking version to wait for tokens

--- a/tests/cli/ui/test_renderer.py
+++ b/tests/cli/ui/test_renderer.py
@@ -275,7 +275,7 @@ class TestRendererToolCallFormatting:
             "name": "read_file",
             "args": {"path": "a" * 300},
         }
-        formatted = Renderer._format_tool_call(tool_call)
+        formatted = Renderer.format_tool_call(tool_call)
         assert "..." in formatted
         assert len(formatted) < 250
 
@@ -285,7 +285,7 @@ class TestRendererToolCallFormatting:
             "name": "get_time",
             "args": {},
         }
-        formatted = Renderer._format_tool_call(tool_call)
+        formatted = Renderer.format_tool_call(tool_call)
         formatted_str = str(formatted)
         assert "⚙ get_time" in formatted_str
 
@@ -295,7 +295,7 @@ class TestRendererToolCallFormatting:
             "name": "search",
             "args": {"query": "test", "limit": 10, "filter": "active"},
         }
-        formatted = Renderer._format_tool_call(tool_call)
+        formatted = Renderer.format_tool_call(tool_call)
         formatted_str = str(formatted)
         assert "⚙ search" in formatted_str
         assert "query :" in formatted_str
@@ -307,7 +307,7 @@ class TestRendererToolCallFormatting:
         tool_call = {
             "args": {"key": "value"},
         }
-        formatted = Renderer._format_tool_call(tool_call)
+        formatted = Renderer.format_tool_call(tool_call)
         formatted_str = str(formatted).lower()
         assert "unknown" in formatted_str or "(" in str(formatted)
 
@@ -316,7 +316,7 @@ class TestRendererToolCallFormatting:
         tool_call = {
             "name": "tool_name",
         }
-        formatted = Renderer._format_tool_call(tool_call)
+        formatted = Renderer.format_tool_call(tool_call)
         formatted_str = str(formatted)
         assert "⚙ tool_name" in formatted_str
 

--- a/tests/fixtures/cli.py
+++ b/tests/fixtures/cli.py
@@ -68,6 +68,7 @@ def mock_renderer():
     renderer.show_welcome = MagicMock()
     renderer.render_help = MagicMock()
     renderer.render_graph = MagicMock()
+    renderer.pending_tool_calls = {}
     return renderer
 
 

--- a/tests/middleware/test_approval.py
+++ b/tests/middleware/test_approval.py
@@ -184,6 +184,7 @@ class TestApprovalMiddleware:
             "args": {"query": "test"},
         }
         request.tool = mock_tool
+        request.state = {"messages": []}
         request.runtime = Mock()
         request.runtime.context = AgentContext(
             approval_mode=ApprovalMode.AGGRESSIVE,
@@ -227,6 +228,7 @@ class TestApprovalMiddleware:
                 "args": {"query": "test"},
             }
             request.tool = mock_tool
+            request.state = {"messages": []}
             request.runtime = Mock()
             request.runtime.context = AgentContext(
                 approval_mode=ApprovalMode.SEMI_ACTIVE,
@@ -253,6 +255,7 @@ class TestApprovalMiddleware:
         request = Mock(spec=ToolCallRequest)
         request.tool_call = {"id": "call_1", "name": "test_tool", "args": {}}
         request.tool = mock_tool
+        request.state = {"messages": []}
         request.runtime = Mock()
         request.runtime.context = AgentContext(
             approval_mode=ApprovalMode.AGGRESSIVE,

--- a/uv.lock
+++ b/uv.lock
@@ -1365,7 +1365,7 @@ wheels = [
 
 [[package]]
 name = "langrepl"
-version = "1.0.2"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
- Render tool calls in interrupt handler before approval prompt
- Extract tool position/total from state in approval middleware
- Skip re-rendering tool calls when ToolMessage arrives
- Add state mock to approval tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tool-position tracking for multi-tool executions, exposing position/total context for tool results.

* **Bug Fixes**
  * Improved assistant/tool message rendering: better pairing of tool calls with results, fewer redundant separators, and more consistent thinking/content placement.

* **Chores**
  * Consolidated module imports for consistency and minor rendering adjustments.

* **Tests**
  * Updated tests and fixtures to reflect public rendering API and new tool-call state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->