### PR TITLE
fix: add repair json

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
     "pytest-asyncio>=1.2.0",
     "pygments-cache>=0.1.3",
     "trafilatura>=2.0.0",
+    "json-repair>=0.54.2",
 ]
 
 [project.urls]

--- a/resources/features/notes.yml
+++ b/resources/features/notes.yml
@@ -2,6 +2,7 @@ features_by_version:
   "1.7.x":
     - "Tool catalog system for reducing token usage"
     - "Config versioning with automatic migration"
+    - "Auto-repair malformed JSON tool calls"
 
   "1.6.x":
     - "Bash mode via Ctrl-B for direct shell commands"

--- a/src/tools/impl/file_system.py
+++ b/src/tools/impl/file_system.py
@@ -2,6 +2,7 @@ import json
 import shutil
 from typing import Annotated
 
+from json_repair import repair_json
 from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
 from langchain_core.tools import ToolException
@@ -60,7 +61,10 @@ def _render_diff_args(args: dict, config: dict) -> str:
         try:
             edits = json.loads(edits)
         except (json.JSONDecodeError, ValueError):
-            pass
+            try:
+                edits = json.loads(repair_json(edits))
+            except Exception:
+                return f"[{theme.error_color}]Cannot parse edits (malformed JSON)[/{theme.error_color}]"
 
     if edits and isinstance(edits, list):
         all_diff_sections = []

--- a/uv.lock
+++ b/uv.lock
@@ -1045,6 +1045,15 @@ wheels = [
 ]
 
 [[package]]
+name = "json-repair"
+version = "0.54.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/05/9fbcd5ffab9c41455e7d80af65a90876718b8ea2fb4525e187ab11836dd4/json_repair-0.54.2.tar.gz", hash = "sha256:4b6b62ce17f1a505b220fa4aadba1fc37dc9c221544f158471efe3775620bad6", size = 38575, upload-time = "2025-11-25T19:31:22.768Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/3a/1b4df9adcd69fee9c9e4b439c13e8c866f2fae520054aede7030b2278be9/json_repair-0.54.2-py3-none-any.whl", hash = "sha256:be51cce5dca97e0c24ebdf61a1ede2449a8a7666012de99467bb7b0afb35179b", size = 29322, upload-time = "2025-11-25T19:31:21.492Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -1453,6 +1462,7 @@ dependencies = [
     { name = "aiofiles" },
     { name = "aiosqlite" },
     { name = "greenlet" },
+    { name = "json-repair" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-aws" },
@@ -1499,6 +1509,7 @@ requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "greenlet", specifier = ">=3.2.4" },
+    { name = "json-repair", specifier = ">=0.54.2" },
     { name = "langchain", specifier = ">=1.0.4" },
     { name = "langchain-anthropic", specifier = ">=1.0.1" },
     { name = "langchain-aws", specifier = ">=1.0.0" },


### PR DESCRIPTION








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automatic repair of malformed JSON in file edit tools and validators using json-repair, so LLM-produced edit payloads parse reliably. Prevents failures with trailing newlines/whitespace and minor JSON issues, and provides clear errors when unrecoverable.

- **Bug Fixes**
  - File system edits: attempt repair_json on parse failure; show a clear error if still invalid.
  - Validators: json_list_parser auto-repairs JSON strings and validates array shape.
  - Integration tests for trailing newline/whitespace, trailing comma, and missing quote cases in edit payloads.

- **Dependencies**
  - Added json-repair>=0.54.2.

<sup>Written for commit 508bcb34f476f65acb79c029ead4c6de8dfb1b66. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->









<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic JSON repair to gracefully handle slightly malformed JSON input.

* **Improvements**
  * More robust parsing and clearer, user-facing error messages when JSON cannot be auto-repaired.

* **Tests**
  * Added tests covering edits with whitespace, trailing newlines, trailing commas, and missing quotes.

* **Chores**
  * Added json-repair dependency and updated release notes to document auto-repair.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->