### PR TITLE
fix: simplify prompt loading in compression handler

### DIFF
--- a/src/cli/handlers/compress.py
+++ b/src/cli/handlers/compress.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import cast
 
 from langchain_core.runnables import RunnableConfig
 
 from src.agents.context import AgentContext
 from src.cli.bootstrap.initializer import initializer
 from src.cli.theme import console, theme
-from src.core.config import CompressionConfig, load_prompt_content
+from src.core.config import CompressionConfig
 from src.core.constants import OS_VERSION, PLATFORM
 from src.core.logging import get_logger
 from src.utils.compression import calculate_message_tokens, compress_messages
@@ -39,9 +40,7 @@ class CompressionHandler:
                 return
 
             compression_config = agent_config.compression or CompressionConfig()
-            prompt_str = await load_prompt_content(
-                ctx.working_dir, compression_config.prompt
-            )
+            prompt_str = compression_config.prompt
 
             async with initializer.get_checkpointer(
                 ctx.agent, ctx.working_dir
@@ -88,7 +87,7 @@ class CompressionHandler:
                         messages,
                         compression_llm,
                         messages_to_keep=compression_config.messages_to_keep,
-                        prompt=prompt_str,
+                        prompt=cast(str, prompt_str),
                         prompt_vars=agent_context.template_vars,
                     )
 


### PR DESCRIPTION
Refactor compression prompt handling and type casting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified compression prompt handling by reading the prompt directly from CompressionConfig and removing async file loading. Added explicit type casting when passing the prompt to the compressor.

- **Refactors**
  - Removed load_prompt_content usage to avoid file I/O and awaits.
  - Used typing.cast(str, prompt) to satisfy type checks.

<sup>Written for commit 777a08012e51a3951620629baa4bc5f8919a0f0d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized compression handler by simplifying prompt loading logic. The compression flow behavior remains unchanged while internal operations have been streamlined for improved clarity and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->