### PR TITLE
fix: preserve MCP tool schema richness

### DIFF
--- a/src/mcp/tool.py
+++ b/src/mcp/tool.py
@@ -12,7 +12,7 @@ from langchain_core.callbacks import (
 from langchain_core.tools import BaseTool, ToolException
 
 from src.core.logging import get_logger
-from src.tools.schema import ToolSchema, parameters_to_model
+from src.tools.schema import ToolSchema
 
 logger = get_logger(__name__)
 
@@ -29,7 +29,7 @@ class LazyMCPTool(BaseTool):
         super().__init__(
             name=tool_schema.name,
             description=tool_schema.description,
-            args_schema=parameters_to_model(tool_schema.name, tool_schema.parameters),
+            args_schema=tool_schema.parameters,
         )
         self._server_name = server_name
         self._loader = loader

--- a/tests/fixtures/agents.py
+++ b/tests/fixtures/agents.py
@@ -142,6 +142,7 @@ def create_mock_tool():
         mock.name = name
         mock.description = f"Mock tool {name}"
         mock.args_schema = MockToolArgs
+        mock.tool_call_schema = MockToolArgs
         mock.handle_tool_error = False
         mock.metadata = None
         return cast(BaseTool, mock)


### PR DESCRIPTION
Use LangChain's tool_call_schema instead of custom parameters_to_model which was losing enum, description, and other schema fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of JSON Schema details in MCP tools by using LangChain’s tool_call_schema directly. Enum values, descriptions, and other fields are now preserved.

- Bug Fixes
  - ToolSchema now reads tool_call_schema and passes its JSON Schema through to args_schema, keeping full schema fidelity.
  - Removed parameters_to_model and updated tests to set tool_call_schema on mocks.

<sup>Written for commit 9b7b3f3784880bfee69084deb3607a6737d2e8a6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tool parameter schema handling by removing intermediate conversion steps, improving code maintainability and reducing processing overhead in tool initialization.
  * Simplified schema construction to directly utilize parameter information from tool definitions, resulting in more efficient internal implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->