### PR TITLE
feat: add stateful MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ https://github.com/user-attachments/assets/f9573310-29dc-4c67-aa1b-cc6b6ab051a2
 - **User Memory** - Project-specific custom instructions and preferences that persist across conversations
 - **Human-in-the-Loop** - Configurable tool approval system with regex-based allow/deny rules
 - **Cost Tracking (Beta)** - Token usage and cost calculation per conversation
-- **MCP Server Support** - Integrate external tool servers via the MCP protocol
+- **MCP Server Support** - Integrate external tool servers via MCP protocol with optional stateful connections
 - **Sandbox (Beta)** - Secure isolated execution for tools with filesystem, network, and syscall restrictions
 
 ## Prerequisites
@@ -569,6 +569,7 @@ skills/
       "args": ["my-mcp-package"],
       "transport": "stdio",
       "enabled": true,
+      "stateful": false,
       "include": ["tool1"],
       "exclude": [],
       "repair_command": "rm -rf .some_cache"
@@ -577,6 +578,7 @@ skills/
 }
 ```
 
+- `stateful`: Keep connection alive between tool calls (default: `false`). Use for servers that need persistent state.
 - `repair_command`: Runs if server fails, then run this command before retrying
 - Suppress stderr: `"command": "sh", "args": ["-c", "npx pkg 2>/dev/null"]`
 - Reference: `mcp:my-server:tool1`

--- a/resources/features/notes.yml
+++ b/resources/features/notes.yml
@@ -1,5 +1,6 @@
 features_by_version:
   "1.10.x":
+    - "Stateful MCP server connections for persistent state"
     - "Sandboxing (file system/network access) for secure execution (Beta)"
     - "Negative pattern support (!pattern) for tools, skills, and sandbox"
   "1.8.x":

--- a/src/langrepl/cli/bootstrap/initializer.py
+++ b/src/langrepl/cli/bootstrap/initializer.py
@@ -204,7 +204,10 @@ class Initializer:
                 compiled_graph, "_tools_in_catalog", []
             )
             self.cached_agent_skills = getattr(compiled_graph, "_agent_skills", [])
-            yield compiled_graph
+            try:
+                yield compiled_graph
+            finally:
+                await mcp_client.close_sessions()
 
     async def get_threads(self, agent: str, working_dir: Path) -> list[dict]:
         """Get all conversation threads with metadata.

--- a/src/langrepl/configs/mcp.py
+++ b/src/langrepl/configs/mcp.py
@@ -35,6 +35,10 @@ class MCPServerConfig(VersionedConfig):
         default=None,
         description="Command list to run if server initialization fails",
     )
+    stateful: bool = Field(
+        default=False,
+        description="Keep server connection alive between tool calls",
+    )
 
 
 class MCPConfig(BaseModel):

--- a/src/langrepl/mcp/factory.py
+++ b/src/langrepl/mcp/factory.py
@@ -43,6 +43,7 @@ class MCPFactory:
             "include": tuple(server.include or []),
             "exclude": tuple(server.exclude or []),
             "repair_command": tuple(server.repair_command or []),
+            "stateful": server.stateful,
         }
         return hashlib.sha256(repr(signature).encode("utf-8")).hexdigest()
 
@@ -70,6 +71,7 @@ class MCPFactory:
         tool_filters = {}
         repair_commands = {}
         server_hashes = {}
+        stateful_servers: set[str] = set()
 
         for name, server in config.servers.items():
             if not server.enabled:
@@ -153,6 +155,9 @@ class MCPFactory:
 
             server_hashes[name] = self._compute_server_hash(server)
 
+            if server.stateful:
+                stateful_servers.add(name)
+
         self._client = MCPClient(
             server_config,
             tool_filters,
@@ -160,6 +165,7 @@ class MCPFactory:
             enable_approval=self.enable_approval,
             cache_dir=cache_dir,
             server_hashes=server_hashes,
+            stateful_servers=stateful_servers,
         )
         self._config_hash = config_hash
         return self._client


### PR DESCRIPTION
Add `stateful` config field to keep MCP server connections alive between tool calls. Useful for servers that need persistent state.

- Add `stateful: bool` to MCPServerConfig (default: false)
- Implement session lifecycle via background tasks
- Cleanup sessions on graph context exit