### PR TITLE
feat: improve CLI logging with verbose mode and file rotation

### DIFF
--- a/src/langrepl/cli/bootstrap/app.py
+++ b/src/langrepl/cli/bootstrap/app.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import os
 import sys
+from pathlib import Path
 
 from langrepl.cli.bootstrap.chat import handle_chat_command
 from langrepl.cli.bootstrap.server import handle_server_command
@@ -11,9 +12,6 @@ from langrepl.cli.theme import console
 from langrepl.configs import ApprovalMode
 from langrepl.core.constants import APP_NAME
 from langrepl.core.logging import configure_logging, get_logger
-
-configure_logging()
-logger = get_logger(__name__)
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -83,6 +81,12 @@ def create_parser() -> argparse.ArgumentParser:
         default=ApprovalMode.SEMI_ACTIVE.value,
         help=f"Tool approval mode ({', '.join(mode.value for mode in ApprovalMode)})",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging to console and .langrepl/app.log",
+    )
 
     return parser
 
@@ -91,6 +95,10 @@ async def main() -> int:
     """Main CLI entry point."""
     parser = create_parser()
     args = parser.parse_args()
+
+    # Configure logging after argument parsing
+    configure_logging(show_logs=args.verbose, working_dir=Path(args.working_dir))
+    logger = get_logger(__name__)
 
     try:
         # Route to server mode if -s flag is present

--- a/src/langrepl/cli/bootstrap/initializer.py
+++ b/src/langrepl/cli/bootstrap/initializer.py
@@ -30,12 +30,15 @@ from langrepl.core.constants import (
     CONFIG_MCP_CACHE_DIR,
     CONFIG_SKILLS_DIR,
 )
+from langrepl.core.logging import get_logger
 from langrepl.core.settings import settings
 from langrepl.llms.factory import LLMFactory
 from langrepl.mcp.factory import MCPFactory
 from langrepl.sandboxes.factory import SandboxFactory
 from langrepl.skills.factory import SkillFactory
 from langrepl.tools.factory import ToolFactory
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
@@ -254,6 +257,7 @@ class Initializer:
                         }
 
                     except Exception:
+                        logger.debug("Thread checkpoint parse failed", exc_info=True)
                         continue
 
                 # Sort threads by timestamp (latest first)
@@ -261,6 +265,7 @@ class Initializer:
                 thread_list.sort(key=lambda t: t.get("timestamp", 0), reverse=True)
                 return thread_list
             except Exception:
+                logger.debug("Get threads failed", exc_info=True)
                 return []
 
 

--- a/src/langrepl/cli/bootstrap/server.py
+++ b/src/langrepl/cli/bootstrap/server.py
@@ -15,7 +15,10 @@ import httpx
 from langrepl.cli.bootstrap.initializer import initializer
 from langrepl.cli.theme import console
 from langrepl.core.constants import CONFIG_LANGGRAPH_FILE_NAME
+from langrepl.core.logging import get_logger
 from langrepl.core.settings import settings
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
@@ -200,7 +203,7 @@ async def _get_or_create_thread(
                 if threads:
                     return threads[0]["thread_id"]
         except Exception:
-            pass
+            logger.debug("Failed to resume thread from server", exc_info=True)
 
     # Create new thread
     response = await client.post(f"{server_url}/threads", json={})
@@ -297,7 +300,7 @@ async def handle_server_command(args) -> int:
                             f"\n# Langgraph Server configuration\n{ignore_pattern}\n"
                         )
             except Exception:
-                pass
+                logger.debug("Git exclude update failed", exc_info=True)
 
         console.print("Starting LangGraph development server...")
         config_path = working_dir / CONFIG_LANGGRAPH_FILE_NAME

--- a/src/langrepl/cli/core/context.py
+++ b/src/langrepl/cli/core/context.py
@@ -8,6 +8,9 @@ from pydantic import BaseModel
 from langrepl.cli.bootstrap.initializer import initializer
 from langrepl.cli.bootstrap.timer import timer
 from langrepl.configs import ApprovalMode
+from langrepl.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class Context(BaseModel):
@@ -61,9 +64,15 @@ class Context(BaseModel):
             agent_config.tools.output_max_tokens if agent_config.tools else None
         )
 
+        resolved_agent = agent or agent_config.name
+        resolved_model = model or agent_config.llm.alias
+
+        logger.info(f"Agent: {resolved_agent}, Model: {resolved_model}")
+        logger.info(f"Thread ID: {thread_id}")
+
         return cls(
-            agent=agent or agent_config.name,
-            model=model or agent_config.llm.alias,
+            agent=resolved_agent,
+            model=resolved_model,
             thread_id=thread_id,
             working_dir=working_dir,
             approval_mode=approval_mode or ApprovalMode.SEMI_ACTIVE,

--- a/src/langrepl/cli/core/session.py
+++ b/src/langrepl/cli/core/session.py
@@ -102,6 +102,7 @@ class Session:
 
     async def _main_loop(self) -> None:
         """Main interactive loop."""
+        logger.info("Session started")
         self.running = True
 
         while self.running:
@@ -126,7 +127,9 @@ class Session:
             except Exception as e:
                 console.print_error(f"Error processing input: {e}")
                 console.print("")
-                logger.debug("Input processing error")
+                logger.debug("Input processing error", exc_info=True)
+
+        logger.info("Session ended")
 
     async def send(self, message: str) -> int:
         """Send a single message in one-shot mode (non-interactive)."""

--- a/src/langrepl/cli/dispatchers/commands.py
+++ b/src/langrepl/cli/dispatchers/commands.py
@@ -18,6 +18,9 @@ from langrepl.cli.handlers import (
     ToolsHandler,
 )
 from langrepl.cli.theme import console
+from langrepl.core.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class CommandDispatcher:
@@ -126,6 +129,7 @@ class CommandDispatcher:
             current_output_tokens=None,
             total_cost=None,
         )
+        logger.info(f"Thread ID: {new_thread_id}")
         console.clear()
 
     async def cmd_exit(self, args: list[str]) -> None:

--- a/src/langrepl/cli/handlers/agents.py
+++ b/src/langrepl/cli/handlers/agents.py
@@ -60,6 +60,10 @@ class AgentHandler:
                     agent=selected_agent_name,
                     model=selected_agent_config.llm.alias,
                 )
+                logger.info(
+                    f"Switched to Agent: {selected_agent_name}, "
+                    f"Model: {selected_agent_config.llm.alias}"
+                )
 
                 # Mark this agent as the new default
                 await initializer.update_default_agent(

--- a/src/langrepl/cli/handlers/compress.py
+++ b/src/langrepl/cli/handlers/compress.py
@@ -115,6 +115,7 @@ class CompressionHandler:
                     current_output_tokens=0,
                     total_cost=0.0,
                 )
+                logger.info(f"Thread ID: {new_thread_id}")
 
                 # Render the compressed messages
                 for message in compressed_messages:

--- a/src/langrepl/cli/handlers/interrupts.py
+++ b/src/langrepl/cli/handlers/interrupts.py
@@ -188,5 +188,5 @@ class InterruptHandler:
                     sys.stdout.flush()
                     return ""
         except Exception:
-            # Any other exception, just return None
+            logger.debug("Interrupt choice failed", exc_info=True)
             return None

--- a/src/langrepl/cli/handlers/models.py
+++ b/src/langrepl/cli/handlers/models.py
@@ -103,11 +103,15 @@ class ModelHandler:
                             else None
                         ),
                     )
+                    logger.info(f"Switched to Model: {selected_model_name}")
                 else:
                     await initializer.update_subagent_llm(
                         agent_name,
                         selected_model_name,
                         self.session.context.working_dir,
+                    )
+                    logger.info(
+                        f"Subagent '{agent_name}' switched to Model: {selected_model_name}"
                     )
                     console.print_success(
                         f"Updated subagent '{agent_name}' to use model '{selected_model_name}'"

--- a/src/langrepl/cli/handlers/replay.py
+++ b/src/langrepl/cli/handlers/replay.py
@@ -83,7 +83,7 @@ class ReplayHandler:
                                     total_cost=channel_values.get("total_cost"),
                                 )
                 except Exception as e:
-                    logger.error(f"Failed to delete checkpoints: {e}")
+                    logger.debug("Checkpoint deletion failed", exc_info=True)
                     console.print_error(
                         f"Warning: Could not rewind conversation history: {e}"
                     )

--- a/src/langrepl/cli/handlers/resume.py
+++ b/src/langrepl/cli/handlers/resume.py
@@ -261,6 +261,7 @@ class ResumeHandler:
                     ),
                     total_cost=latest_channel_values.get("total_cost"),
                 )
+                logger.info(f"Thread ID: {thread_id}")
 
         except Exception as e:
             console.print_error(f"Error loading thread history: {e}")

--- a/src/langrepl/cli/resolvers/file.py
+++ b/src/langrepl/cli/resolvers/file.py
@@ -6,8 +6,11 @@ from shlex import quote
 from prompt_toolkit.completion import Completion
 
 from langrepl.cli.resolvers.base import RefType, Resolver
+from langrepl.core.logging import get_logger
 from langrepl.utils.bash import execute_bash_command
 from langrepl.utils.path import resolve_path
+
+logger = get_logger(__name__)
 
 
 class FileResolver(Resolver):
@@ -84,6 +87,7 @@ class FileResolver(Resolver):
             resolved = resolve_path(str(working_dir), ref)
             return str(resolved)
         except Exception:
+            logger.debug("Failed to resolve file reference", exc_info=True)
             return ref
 
     async def complete(self, fragment: str, ctx: dict, limit: int) -> list[Completion]:
@@ -125,6 +129,6 @@ class FileResolver(Resolver):
                 )
 
         except Exception:
-            pass
+            logger.debug("File completion failed", exc_info=True)
 
         return completions

--- a/src/langrepl/cli/resolvers/image.py
+++ b/src/langrepl/cli/resolvers/image.py
@@ -7,6 +7,7 @@ from typing import Any
 from prompt_toolkit.completion import Completion
 
 from langrepl.cli.resolvers.base import RefType, Resolver
+from langrepl.core.logging import get_logger
 from langrepl.utils.bash import execute_bash_command
 from langrepl.utils.image import (
     SUPPORTED_IMAGE_EXTENSIONS,
@@ -17,6 +18,8 @@ from langrepl.utils.image import (
     read_image_as_base64,
 )
 from langrepl.utils.path import resolve_path
+
+logger = get_logger(__name__)
 
 
 class ImageResolver(Resolver):
@@ -100,6 +103,7 @@ class ImageResolver(Resolver):
                 return str(resolved)
             return ref
         except Exception:
+            logger.debug("Failed to resolve image reference", exc_info=True)
             return ref
 
     async def complete(self, fragment: str, ctx: dict, limit: int) -> list[Completion]:
@@ -137,7 +141,7 @@ class ImageResolver(Resolver):
                 )
 
         except Exception:
-            pass
+            logger.debug("Image completion failed", exc_info=True)
 
         return completions
 

--- a/src/langrepl/cli/ui/prompt.py
+++ b/src/langrepl/cli/ui/prompt.py
@@ -16,8 +16,11 @@ from langrepl.cli.completers import CompleterRouter
 from langrepl.cli.core.context import Context
 from langrepl.cli.ui.shared import create_bottom_toolbar, create_prompt_style
 from langrepl.core.constants import CONFIG_HISTORY_FILE_NAME
+from langrepl.core.logging import get_logger
 from langrepl.core.settings import settings
 from langrepl.utils.cost import calculate_context_percentage, format_cost, format_tokens
+
+logger = get_logger(__name__)
 
 
 class InteractivePrompt:
@@ -271,6 +274,7 @@ class InteractivePrompt:
         try:
             app.loop.call_later(self._ctrl_c_timeout, hide)
         except Exception:
+            logger.debug("Hide message timer failed", exc_info=True)
             self._reset_ctrl_c_state()
 
     def refresh_style(self) -> None:

--- a/src/langrepl/core/constants.py
+++ b/src/langrepl/core/constants.py
@@ -24,6 +24,7 @@ CONFIG_SKILLS_DIR = Path(f"{CONFIG_DIR_NAME}/skills")
 CONFIG_SANDBOXES_DIR = Path(f"{CONFIG_DIR_NAME}/sandboxes")
 CONFIG_MCP_CACHE_DIR = Path(f"{CONFIG_DIR_NAME}/cache/mcp")
 CONFIG_SANDBOX_CACHE_DIR = Path(f"{CONFIG_DIR_NAME}/cache/sandboxes")
+CONFIG_LOG_DIR = Path(f"{CONFIG_DIR_NAME}/logs")
 
 DEFAULT_CONFIG_DIR_NAME = "resources.configs.default"
 

--- a/src/langrepl/core/logging.py
+++ b/src/langrepl/core/logging.py
@@ -1,34 +1,51 @@
 import logging
 import warnings
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
 
+from rich.logging import RichHandler
+
+from langrepl.core.constants import CONFIG_LOG_DIR
 from langrepl.core.settings import settings
 
-LOG_FORMAT = (
+# File format includes full context (for log file)
+FILE_LOG_FORMAT = (
     "%(asctime)s - %(name)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s"
 )
 
 
-def configure_logging(show_logs: bool = False) -> None:
+def configure_logging(show_logs: bool = False, working_dir: Path = Path.cwd()) -> None:
     """Configure application logging.
 
     Args:
-        show_logs: Whether to show logs on console. If False, logs are hidden by default.
+        show_logs: Enable verbose logging (console + file). If False, logs are hidden.
+        working_dir: Working directory for log file.
     """
-    # Create formatter
-    formatter = logging.Formatter(LOG_FORMAT)
-
     # Configure root logger
     root_logger = logging.getLogger()
     root_logger.setLevel(settings.log_level)
 
     # Clear existing handlers
-    for handler in root_logger.handlers:
+    for handler in root_logger.handlers[:]:
         root_logger.removeHandler(handler)
 
     # Suppress langchain warnings
     logging.getLogger("langchain_google_genai._function_utils").setLevel(logging.ERROR)
     logging.getLogger("langchain_anthropic").setLevel(logging.ERROR)
     logging.getLogger("langchain_openai").setLevel(logging.ERROR)
+
+    # Suppress HTTP client loggers (noisy at INFO level)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+    logging.getLogger("httpcore").setLevel(logging.WARNING)
+    logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+    # Suppress checkpointer/database loggers
+    logging.getLogger("langgraph.checkpoint.sqlite.aio").setLevel(logging.WARNING)
+    logging.getLogger("langgraph.checkpoint").setLevel(logging.WARNING)
+    logging.getLogger("aiosqlite").setLevel(logging.WARNING)
+
+    # Suppress markdown parser debug logs
+    logging.getLogger("markdown_it").setLevel(logging.WARNING)
 
     # Suppress langchain_aws warnings
     warnings.filterwarnings("ignore", module="langchain_aws.chat_models.bedrock")
@@ -41,11 +58,36 @@ def configure_logging(show_logs: bool = False) -> None:
         module="pydantic.v1.main",
     )
 
-    # Add console handler only if show_logs is True
     if show_logs:
-        console_handler = logging.StreamHandler()
-        console_handler.setFormatter(formatter)
+        # Pretty console logging with RichHandler (shows file:line automatically)
+        console_handler = RichHandler(
+            show_time=True,
+            show_level=True,
+            show_path=True,
+            rich_tracebacks=True,
+            tracebacks_show_locals=False,
+        )
         root_logger.addHandler(console_handler)
+
+        # File logging with daily rotation
+        log_dir = working_dir / CONFIG_LOG_DIR
+        try:
+            log_dir.mkdir(parents=True, exist_ok=True)
+            file_handler = TimedRotatingFileHandler(
+                log_dir / "app.log",
+                when="midnight",
+                interval=1,
+                backupCount=7,  # Keep 7 days of logs
+                encoding="utf-8",
+            )
+            # Rotated files will be named app.log.YYYY-MM-DD
+            file_handler.suffix = "%Y-%m-%d"
+            file_handler.setFormatter(logging.Formatter(FILE_LOG_FORMAT))
+            root_logger.addHandler(file_handler)
+
+            logging.getLogger(__name__).info("Logging initialized")
+        except (OSError, PermissionError):
+            pass  # Sandbox may block file creation
 
 
 def get_logger(name: str) -> logging.Logger:

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -110,7 +110,6 @@ class ServerSettings(BaseModel):
 
 class Settings(BaseSettings):
     log_level: str = Field(default="INFO", description="The log level")
-    log_file: str = Field(default="app.log", description="The log file")
     suppress_grpc_warnings: bool = Field(
         default=True, description="Suppress gRPC warnings"
     )


### PR DESCRIPTION
- Add -v/--verbose flag to enable logging
- Use RichHandler for pretty console output
- Add daily log rotation with 7-day retention in .langrepl/logs/
- Suppress noisy third-party loggers
- Add debug logging to silent exception handlers
- Log session lifecycle and agent/model/thread changes