### PR TITLE
chore: Add configuration for Claude Opus model in bedrock.yml

### DIFF
--- a/resources/configs/default/llms/bedrock.yml
+++ b/resources/configs/default/llms/bedrock.yml
@@ -48,3 +48,19 @@
     output_tokens_per_second: 266.67
     check_every_n_seconds: 0.05
     max_bucket_size: 100
+
+- version: 1.0.0
+  model: eu.anthropic.claude-opus-4-5-20251101-v1:0
+  alias: opus-4.5-bedrock
+  provider: bedrock
+  max_tokens: 10000
+  temperature: 0.1
+  context_window: 200000
+  input_cost_per_mtok: 5.0
+  output_cost_per_mtok: 25.0
+  rate_config:
+    requests_per_second: 16.67
+    input_tokens_per_second: 1333.33
+    output_tokens_per_second: 266.67
+    check_every_n_seconds: 0.05
+    max_bucket_size: 100


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Claude Opus 4.5 (eu.anthropic.claude-opus-4-5-20251101-v1:0) to bedrock.yml with alias opus-4.5-bedrock, max_tokens 10k, temperature 0.1, 200k context, pricing, and rate limits to enable selection and controlled usage.

<sup>Written for commit 0bbb2a82a3c55502b8e4850a1a25f213571bd508. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

