### PR TITLE
feat: add /todo command

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,18 @@ Lists all skills available to the current agent with interactive selector. Skill
 ### Utilities
 
 <details>
+<summary><code>/todo [N]</code> - View current todo list</summary>
+
+Shows the current todo list. Specify optional number to limit displayed items (default: 10).
+
+```bash
+/todo       # Show max 10 items
+/todo 20    # Show max 20 items
+```
+
+</details>
+
+<details>
 <summary><code>/graph [--browser]</code> - Visualize agent graph</summary>
 
 Renders in terminal (ASCII) or opens in browser with `--browser` flag.

--- a/resources/features/notes.yml
+++ b/resources/features/notes.yml
@@ -1,5 +1,6 @@
 features_by_version:
   "1.10.x":
+    - "/todo [N] command to view current todo list"
     - "OAuth user redirect flow for remote MCP servers"
     - "Stateful MCP server connections for persistent state"
     - "Sandboxing (file system/network access) for secure execution (Beta)"

--- a/src/langrepl/cli/dispatchers/commands.py
+++ b/src/langrepl/cli/dispatchers/commands.py
@@ -15,6 +15,7 @@ from langrepl.cli.handlers import (
     ReplayHandler,
     ResumeHandler,
     SkillsHandler,
+    TodoHandler,
     ToolsHandler,
 )
 from langrepl.cli.theme import console
@@ -40,6 +41,7 @@ class CommandDispatcher:
         self.replay_handler = ReplayHandler(session)
         self.compression_handler = CompressionHandler(session)
         self.graph_handler = GraphHandler(session)
+        self.todo_handler = TodoHandler(session)
 
     def _register_commands(self) -> dict[str, Callable]:
         """Register all available commands."""
@@ -58,6 +60,7 @@ class CommandDispatcher:
             "/resume": self.cmd_resume,
             "/replay": self.cmd_replay,
             "/compress": self.cmd_compress,
+            "/todo": self.cmd_todo,
         }
 
     async def dispatch(self, command_line: str) -> None:
@@ -158,3 +161,15 @@ class CommandDispatcher:
             return
 
         await self.graph_handler.handle(open_browser="--browser" in args)
+
+    async def cmd_todo(self, args: list[str]) -> None:
+        """Show current todo list."""
+        max_items = 10
+        if args:
+            try:
+                max_items = int(args[0])
+            except ValueError:
+                console.print_error(f"Invalid number: {args[0]}")
+                console.print("")
+                return
+        await self.todo_handler.handle(max_items)

--- a/src/langrepl/cli/handlers/__init__.py
+++ b/src/langrepl/cli/handlers/__init__.py
@@ -10,6 +10,7 @@ from langrepl.cli.handlers.models import ModelHandler
 from langrepl.cli.handlers.replay import ReplayHandler
 from langrepl.cli.handlers.resume import ResumeHandler
 from langrepl.cli.handlers.skills import SkillsHandler
+from langrepl.cli.handlers.todo import TodoHandler
 from langrepl.cli.handlers.tools import ToolsHandler
 
 __all__ = [
@@ -23,5 +24,6 @@ __all__ = [
     "ReplayHandler",
     "ResumeHandler",
     "SkillsHandler",
+    "TodoHandler",
     "ToolsHandler",
 ]

--- a/src/langrepl/cli/handlers/todo.py
+++ b/src/langrepl/cli/handlers/todo.py
@@ -1,0 +1,57 @@
+"""Todo handler for displaying current task list."""
+
+from langchain_core.runnables import RunnableConfig
+
+from langrepl.cli.bootstrap.initializer import initializer
+from langrepl.cli.theme import console
+from langrepl.core.logging import get_logger
+from langrepl.tools.internal.todo import format_todos
+
+logger = get_logger(__name__)
+
+
+class TodoHandler:
+    """Handles todo list display."""
+
+    def __init__(self, session) -> None:
+        """Initialize with reference to CLI session."""
+        self.session = session
+
+    async def handle(self, max_items: int = 10) -> None:
+        """Show current todo list."""
+        try:
+            async with initializer.get_checkpointer(
+                self.session.context.agent, self.session.context.working_dir
+            ) as checkpointer:
+                config = RunnableConfig(
+                    configurable={"thread_id": self.session.context.thread_id}
+                )
+                latest_checkpoint = await checkpointer.aget_tuple(config)
+
+                if not latest_checkpoint or not latest_checkpoint.checkpoint:
+                    console.print_error("No todos currently")
+                    console.print("")
+                    return
+
+                channel_values = latest_checkpoint.checkpoint.get("channel_values", {})
+                todos = channel_values.get("todos")
+
+                if not todos:
+                    console.print_error("No todos currently")
+                    console.print("")
+                    return
+
+                formatted = format_todos(
+                    todos,
+                    max_items=max_items,
+                    max_completed=max_items,
+                    show_completed_indicator=False,
+                )
+                indented = "\n".join(f"  {line}" for line in formatted.split("\n"))
+                console.print(indented, markup=True)
+                console.print("")
+
+        except Exception as e:
+            console.print_error(f"Error displaying todos: {e}")
+            console.print("")
+            logger.debug("Todo display error", exc_info=True)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a /todo command to view the current thread’s todo list with a clean, readable output. Supports an optional item limit (default: 10) and handles empty states gracefully.

- **New Features**
  - New /todo [N] CLI command registered and wired into the dispatcher.
  - Reads todos from the thread checkpoint; shows a friendly “No todos” message when empty.
  - Validates numeric argument and prints an error for invalid input.
  - Improved formatting: prioritizes in-progress tasks, includes completed items, and shows a “+N more” indicator when truncated.
  - Docs updated with usage examples and feature notes.

<sup>Written for commit 57a408e5aeca1b2e738229d4f789a474a1e9d333. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

