### PR TITLE
feat(cli): auto-detect terminal theme (dark/light)

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ TOOL_SETTINGS__SEARCH_LIMIT=25       # Grep search limit (default: 25)
 #### CLI Settings
 
 ```bash
-CLI__THEME=dracula                   # UI theme (default: dracula)
+CLI__THEME=tokyo-night               # UI theme (default: none (auto-detect), possible values: tokyo-day, tokyo-night)
 CLI__PROMPT_STYLE="❯ "               # Prompt style (default: "❯ ")
 CLI__ENABLE_WORD_WRAP=true           # Word wrap (default: true)
 CLI__EDITOR=nano                     # Editor for /memory (default: nano)

--- a/src/langrepl/cli/theme/__init__.py
+++ b/src/langrepl/cli/theme/__init__.py
@@ -1,7 +1,21 @@
-from langrepl.cli.theme import tokyo_night  # noqa: F401
+from langrepl.cli.theme import tokyo_day, tokyo_night  # noqa: F401
 from langrepl.cli.theme.console import ThemedConsole
+from langrepl.cli.theme.detect import detect_terminal_theme
 from langrepl.cli.theme.registry import get_theme
 from langrepl.core.settings import settings
 
-theme = get_theme(settings.cli.theme)
+# Map detected theme mode to theme name
+_THEME_MAP = {
+    "dark": "tokyo-night",
+    "light": "tokyo-day",
+}
+
+# Use user setting if set, otherwise auto-detect
+if settings.cli.theme is not None:
+    _theme_name = settings.cli.theme
+else:
+    _detected_mode = detect_terminal_theme()
+    _theme_name = _THEME_MAP.get(_detected_mode, "tokyo-night")
+
+theme = get_theme(_theme_name)
 console = ThemedConsole(theme)

--- a/src/langrepl/cli/theme/console.py
+++ b/src/langrepl/cli/theme/console.py
@@ -12,7 +12,6 @@ class ThemedConsole:
         self.console = Console(
             theme=console_theme.rich_theme,
             force_terminal=True,
-            color_system="truecolor",
         )
 
     def print(self, *args, style: str = "default", **kwargs):

--- a/src/langrepl/cli/theme/detect.py
+++ b/src/langrepl/cli/theme/detect.py
@@ -1,0 +1,198 @@
+"""Terminal theme detection utilities.
+
+Detects whether the terminal is using a dark or light color scheme
+by querying the terminal's background color.
+"""
+
+import os
+import re
+import select
+import sys
+
+
+def _detect_via_osc11() -> str | None:
+    """Detect terminal theme using OSC 11 query.
+
+    Sends an escape sequence to query the terminal's background color.
+    Works with xterm-compatible terminals like iTerm2, Terminal.app,
+    Kitty, Alacritty, GNOME Terminal, VS Code, etc.
+
+    Returns:
+        'dark', 'light', or None if detection fails.
+    """
+    # Only works with real TTYs
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        return None
+
+    # Import here to avoid issues on non-Unix systems
+    try:
+        import termios
+        import tty
+    except ImportError:
+        return None
+
+    fd = sys.stdin.fileno()
+
+    try:
+        old_settings = termios.tcgetattr(fd)
+    except termios.error:
+        return None
+
+    try:
+        tty.setraw(fd)
+
+        # OSC 11 query: request background color
+        # \033]11;?\033\\ is the xterm control sequence
+        sys.stdout.write("\033]11;?\033\\")
+        sys.stdout.flush()
+
+        # Wait for response with 100ms timeout
+        if select.select([sys.stdin], [], [], 0.1)[0]:
+            response = ""
+            # Read response character by character
+            while select.select([sys.stdin], [], [], 0.05)[0]:
+                char = sys.stdin.read(1)
+                response += char
+                # Stop if we've received the terminator
+                if response.endswith("\\") or response.endswith("\a"):
+                    break
+
+            # Parse response: rgb:RRRR/GGGG/BBBB
+            match = re.search(
+                r"rgb:([0-9a-fA-F]+)/([0-9a-fA-F]+)/([0-9a-fA-F]+)", response
+            )
+            if match:
+                # Take first 2 hex digits (scale to 0-255)
+                r = int(match.group(1)[:2], 16)
+                g = int(match.group(2)[:2], 16)
+                b = int(match.group(3)[:2], 16)
+
+                # Calculate perceived luminance using YCbCr formula
+                luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+                return "light" if luminance > 0.5 else "dark"
+    except Exception:
+        pass
+    finally:
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        except Exception:
+            pass
+
+    return None
+
+
+def _detect_via_colorfgbg() -> str | None:
+    """Detect terminal theme from COLORFGBG environment variable.
+
+    This variable is set by some terminals (rxvt, etc.) in the format
+    'foreground;background' using ANSI color indices.
+
+    Returns:
+        'dark', 'light', or None if detection fails.
+    """
+    colorfgbg = os.environ.get("COLORFGBG", "")
+    if colorfgbg:
+        parts = colorfgbg.split(";")
+        if len(parts) >= 2 and parts[-1].isdigit():
+            bg = int(parts[-1])
+            # 7 = white, 15 = bright white -> light theme
+            return "light" if bg in (7, 15) else "dark"
+    return None
+
+
+def _detect_via_os() -> str | None:
+    """Detect OS-level dark/light mode setting.
+
+    Supports:
+    - macOS: Uses 'defaults read' to check AppleInterfaceStyle
+    - Linux: Uses 'gsettings' to check GTK theme (GNOME/GTK-based)
+
+    Returns:
+        'dark', 'light', or None if detection fails.
+    """
+    import subprocess
+
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["defaults", "read", "-g", "AppleInterfaceStyle"],
+                capture_output=True,
+                text=True,
+                timeout=1,
+            )
+            # Command succeeds if dark mode is enabled (returns "Dark")
+            # Command fails (exit code 1) if light mode is active
+            return "dark" if result.returncode == 0 else "light"
+        except Exception:
+            pass
+
+    elif sys.platform == "linux":
+        # Try GNOME/GTK first (gsettings)
+        try:
+            # Try freedesktop color-scheme first (modern)
+            result = subprocess.run(
+                ["gsettings", "get", "org.gnome.desktop.interface", "color-scheme"],
+                capture_output=True,
+                text=True,
+                timeout=1,
+            )
+            stdout = result.stdout.strip().lower()
+
+            # Fallback to gtk-theme if color-scheme not set
+            if not stdout or stdout == "''":
+                result = subprocess.run(
+                    ["gsettings", "get", "org.gnome.desktop.interface", "gtk-theme"],
+                    capture_output=True,
+                    text=True,
+                    timeout=1,
+                )
+                stdout = result.stdout.strip().lower()
+
+            if stdout and stdout != "''":
+                if "-dark" in stdout or "'dark'" in stdout:
+                    return "dark"
+                return "light"
+        except Exception:
+            pass
+
+        # Try KDE Plasma (kreadconfig5/kreadconfig6)
+        for cmd in ["kreadconfig6", "kreadconfig5"]:
+            try:
+                result = subprocess.run(
+                    [
+                        cmd,
+                        "--file",
+                        "kdeglobals",
+                        "--group",
+                        "General",
+                        "--key",
+                        "ColorScheme",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=1,
+                )
+                if result.returncode == 0:
+                    stdout = result.stdout.strip().lower()
+                    if stdout:
+                        return "dark" if "dark" in stdout else "light"
+            except Exception:
+                pass
+
+    return None
+
+
+def detect_terminal_theme() -> str:
+    """Detect terminal theme with fallback chain.
+
+    Tries multiple detection methods in order:
+    1. OSC 11 terminal query (most accurate)
+    2. COLORFGBG environment variable
+    3. OS-level dark mode (macOS/Linux)
+    4. Default to 'dark'
+
+    Returns:
+        'dark' or 'light'
+    """
+    result = _detect_via_osc11() or _detect_via_colorfgbg() or _detect_via_os()
+    return result or "dark"

--- a/src/langrepl/cli/theme/tokyo_day.py
+++ b/src/langrepl/cli/theme/tokyo_day.py
@@ -1,0 +1,177 @@
+"""Tokyo Day theme colors and palette for light terminal backgrounds."""
+
+from dataclasses import dataclass
+
+from rich.style import Style
+from rich.theme import Theme
+
+from langrepl.cli.theme.base import BaseTheme
+from langrepl.cli.theme.registry import register_theme
+
+
+@dataclass
+class TokyoDayColors:
+    """Tokyo Day color scheme definition (light mode variant)."""
+
+    # Light backgrounds
+    light_gray: str = "#d5d6db"
+    off_white: str = "#e1e2e7"
+    pale_blue: str = "#e9e9ed"
+    mist: str = "#f0f0f4"
+
+    # Dark text colors
+    deep_blue: str = "#343b58"
+    slate_blue: str = "#565f89"
+    gray_blue: str = "#6b7089"
+    light_slate: str = "#8990a3"
+
+    # Accent colors (adjusted for light background visibility)
+    deep_azure: str = "#2e5a98"
+    ocean_blue: str = "#166775"
+    royal_purple: str = "#7847bd"
+    forest_teal: str = "#166775"
+    amber: str = "#8a5d00"
+    magenta: str = "#9e3366"
+    rust_orange: str = "#b55a1a"
+    sky_blue: str = "#0f6d8f"
+    steel_blue: str = "#8ca6bf"
+
+
+@register_theme("tokyo-day")
+class TokyoDayTheme(BaseTheme):
+    """Tokyo Day theme implementation (light mode)."""
+
+    def __init__(self):
+        self.colors = TokyoDayColors()
+        self.rich_theme = self._create_rich_theme()
+
+    def _create_rich_theme(self) -> Theme:
+        """Create Rich Theme with Tokyo Day colors."""
+        c = self.colors
+        return Theme(
+            {
+                # Basic text styles
+                "default": Style(color=c.deep_blue),
+                "primary": Style(color=c.deep_blue),
+                "secondary": Style(color=c.slate_blue),
+                "muted": Style(color=c.gray_blue),
+                "muted.bold": Style(color=c.gray_blue, bold=True),
+                "disabled": Style(color=c.light_slate),
+                # Accent styles
+                "accent": Style(color=c.deep_azure, bold=True),
+                "accent.primary": Style(color=c.deep_azure),
+                "accent.secondary": Style(color=c.ocean_blue),
+                "accent.tertiary": Style(color=c.royal_purple),
+                # Semantic styles
+                "success": Style(color=c.forest_teal),
+                "warning": Style(color=c.amber),
+                "error": Style(color=c.magenta),
+                "info": Style(color=c.deep_azure),
+                # UI element styles
+                "border": Style(color=c.light_slate),
+                "prompt": Style(color=c.deep_azure, bold=True),
+                "command": Style(color=c.royal_purple),
+                "option": Style(color=c.ocean_blue),
+                "indicator": Style(color=c.forest_teal),
+                # Code syntax highlighting
+                "code": Style(color=c.forest_teal, bold=False),
+                "code.keyword": Style(color=c.royal_purple, bold=True),
+                "code.string": Style(color=c.forest_teal),
+                "code.number": Style(color=c.rust_orange),
+                "code.comment": Style(color=c.gray_blue, italic=True),
+                "code.operator": Style(color=c.sky_blue),
+                # Markdown specific styles
+                "markdown.code": Style(color=c.royal_purple, bold=True),
+                # Special elements
+                "timestamp": Style(color=c.gray_blue, italic=True),
+            }
+        )
+
+    # Semantic color accessors for BaseTheme protocol
+    @property
+    def primary_text(self) -> str:
+        return self.colors.deep_blue
+
+    @property
+    def secondary_text(self) -> str:
+        return self.colors.slate_blue
+
+    @property
+    def muted_text(self) -> str:
+        return self.colors.gray_blue
+
+    @property
+    def background(self) -> str:
+        return self.colors.off_white
+
+    @property
+    def background_light(self) -> str:
+        return self.colors.pale_blue
+
+    @property
+    def success_color(self) -> str:
+        return self.colors.forest_teal
+
+    @property
+    def error_color(self) -> str:
+        return self.colors.magenta
+
+    @property
+    def warning_color(self) -> str:
+        return self.colors.amber
+
+    @property
+    def info_color(self) -> str:
+        return self.colors.deep_azure
+
+    @property
+    def prompt_color(self) -> str:
+        return self.colors.deep_azure
+
+    @property
+    def accent_color(self) -> str:
+        return self.colors.ocean_blue
+
+    @property
+    def indicator_color(self) -> str:
+        return self.colors.forest_teal
+
+    @property
+    def command_color(self) -> str:
+        return self.colors.royal_purple
+
+    @property
+    def addition_color(self) -> str:
+        return self.colors.forest_teal
+
+    @property
+    def deletion_color(self) -> str:
+        return self.colors.magenta
+
+    @property
+    def context_color(self) -> str:
+        return self.colors.slate_blue
+
+    @property
+    def approval_semi_active(self) -> str:
+        return self.colors.deep_azure
+
+    @property
+    def approval_active(self) -> str:
+        return self.colors.amber
+
+    @property
+    def approval_aggressive(self) -> str:
+        return self.colors.royal_purple
+
+    @property
+    def selection_color(self) -> str:
+        return self.colors.forest_teal
+
+    @property
+    def spinner_color(self) -> str:
+        return self.colors.forest_teal
+
+    @property
+    def danger_color(self) -> str:
+        return self.colors.magenta

--- a/src/langrepl/core/constants.py
+++ b/src/langrepl/core/constants.py
@@ -2,7 +2,7 @@ import platform
 from pathlib import Path
 
 UNKNOWN = "unknown"
-DEFAULT_THEME = "tokyo-night"
+
 APP_NAME = "langrepl"
 CONFIG_DIR_NAME = f".{APP_NAME}"
 CONFIG_MCP_FILE_NAME = Path(f"{CONFIG_DIR_NAME}/config.mcp.json")

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -4,8 +4,6 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from langrepl.core.constants import DEFAULT_THEME
-
 try:
     load_dotenv(".env")
 except PermissionError:
@@ -85,7 +83,9 @@ class CLISettings(BaseModel):
     """CLI-specific settings."""
 
     # Appearance settings
-    theme: str = Field(default=DEFAULT_THEME, description="UI theme")
+    theme: str | None = Field(
+        default=None, description="UI theme (auto-detect if None)"
+    )
     prompt_style: str = Field(default="❯ ", description="Prompt style")
 
     # Behavior settings


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Auto-detects terminal dark/light mode at startup and switches the CLI theme between Tokyo Night and the new Tokyo Day for better readability. Falls back to dark when detection isn’t supported.

- **New Features**
  - Added light theme (Tokyo Day) and automatic theme detection: OSC 11 > COLORFGBG > OS hints (macOS, GNOME/KDE) > default dark.
  - CLI now maps detected mode to tokyo-night/tokyo-day at startup; removed forced color_system to let Rich negotiate colors.

<sup>Written for commit 3a48fb19d86d9a7e2ef17373aaa15c1f633f7559. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

