### PR TITLE
feat: restore pending approval panel on resume

### DIFF
--- a/src/langrepl/cli/bootstrap/chat.py
+++ b/src/langrepl/cli/bootstrap/chat.py
@@ -24,21 +24,21 @@ async def handle_chat_command(args) -> int:
 
         # One-shot mode
         if args.message:
-            if args.resume:
-                await session.command_dispatcher.resume_handler.handle(
-                    context.thread_id, render_history=False
-                )
-            return await session.send(args.message)
+            return await session.send(
+                args.message,
+                resume_thread_id=context.thread_id if args.resume else None,
+            )
 
         # Interactive mode
         first_start = True
         while True:
-            if first_start and args.resume:
-                await session.command_dispatcher.resume_handler.handle(
-                    context.thread_id
-                )
-
-            await session.start(show_welcome=first_start and not args.resume)
+            resume_thread_id = (
+                context.thread_id if first_start and args.resume else None
+            )
+            await session.start(
+                show_welcome=first_start and not args.resume,
+                resume_thread_id=resume_thread_id,
+            )
             first_start = False
 
             if session.needs_reload:

--- a/tests/cli/bootstrap/test_chat.py
+++ b/tests/cli/bootstrap/test_chat.py
@@ -38,10 +38,8 @@ class TestHandleChatCommand:
 
         result = await handle_chat_command(mock_app_args)
 
-        patch_chat_dependencies[
-            "session"
-        ].command_dispatcher.resume_handler.handle.assert_called_once_with(
-            mock_context.thread_id
+        patch_chat_dependencies["session"].start.assert_called_once_with(
+            show_welcome=False, resume_thread_id=mock_context.thread_id
         )
         assert result == 0
 
@@ -88,12 +86,12 @@ class TestHandleChatCommand:
         await handle_chat_command(mock_app_args)
 
         patch_chat_dependencies["session"].start.assert_called_once_with(
-            show_welcome=True
+            show_welcome=True, resume_thread_id=None
         )
 
     @pytest.mark.asyncio
     async def test_handle_chat_command_hides_welcome_on_resume(
-        self, mock_app_args, patch_chat_dependencies
+        self, mock_app_args, patch_chat_dependencies, mock_context
     ):
         """Test that handle_chat_command hides welcome when resuming."""
         mock_app_args.resume = True
@@ -101,7 +99,7 @@ class TestHandleChatCommand:
         await handle_chat_command(mock_app_args)
 
         patch_chat_dependencies["session"].start.assert_called_once_with(
-            show_welcome=False
+            show_welcome=False, resume_thread_id=mock_context.thread_id
         )
 
     @pytest.mark.asyncio
@@ -145,7 +143,9 @@ class TestHandleChatCommand:
 
         result = await handle_chat_command(mock_app_args)
 
-        patch_chat_dependencies["session"].send.assert_called_once_with("test message")
+        patch_chat_dependencies["session"].send.assert_called_once_with(
+            "test message", resume_thread_id=None
+        )
         patch_chat_dependencies["session"].start.assert_not_called()
         assert result == 0
 
@@ -159,12 +159,9 @@ class TestHandleChatCommand:
 
         result = await handle_chat_command(mock_app_args)
 
-        patch_chat_dependencies[
-            "session"
-        ].command_dispatcher.resume_handler.handle.assert_called_once_with(
-            mock_context.thread_id, render_history=False
+        patch_chat_dependencies["session"].send.assert_called_once_with(
+            "test message", resume_thread_id=mock_context.thread_id
         )
-        patch_chat_dependencies["session"].send.assert_called_once_with("test message")
         patch_chat_dependencies["session"].start.assert_not_called()
         assert result == 0
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored the pending approval panel when resuming a conversation so interrupted threads prompt for approval and then continue. Works in both interactive and one-shot modes via a unified resume flow.

- **Bug Fixes**
  - Detects pending interrupts on resume and shows the approval panel before continuing.
  - Session.start/send accept resume_thread_id and handle resume consistently; history rendering remains optional.
  - Message dispatcher streams resumed execution using a Command; _stream_response accepts Command.

<sup>Written for commit 10977d2dda4933d3d952e26b81fd8a7aaf04d3a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

