### PR TITLE
fix: dep conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,15 @@ Aliases: `langrepl` or `lg`
 
 **Quick try (no installation):**
 ```bash
-uvx langrepl
-uvx langrepl -w /path  # specify working dir
+uvx --python 3.13 langrepl
+uvx --python 3.13 langrepl -w /path  # specify working dir
 ```
 
 **Install globally:**
 ```bash
-uv tool install langrepl
+uv tool install --python 3.13 langrepl
 # or with pipx:
-pipx install langrepl
+pipx install --python 3.13 langrepl
 ```
 
 Then run from any directory:
@@ -111,13 +111,13 @@ langrepl -w /path     # specify working directory
 
 **Quick try (no installation):**
 ```bash
-uvx --from git+https://github.com/midodimori/langrepl langrepl
-uvx --from git+https://github.com/midodimori/langrepl langrepl -w /path  # specify working dir
+uvx --python 3.13 --from git+https://github.com/midodimori/langrepl langrepl
+uvx --python 3.13 --from git+https://github.com/midodimori/langrepl langrepl -w /path  # specify working dir
 ```
 
 **Install globally:**
 ```bash
-uv tool install git+https://github.com/midodimori/langrepl
+uv tool install --python 3.13 git+https://github.com/midodimori/langrepl
 ```
 
 Then run from any directory:

--- a/src/langrepl/cli/core/session.py
+++ b/src/langrepl/cli/core/session.py
@@ -286,7 +286,7 @@ class Session:
                 latest_version, upgrade_command = updates
                 if latest_version and upgrade_command:
                     console.print_warning(
-                        f"[muted]New version available ({latest_version}). Upgrade with: [muted.bold]uv tool install langrepl --upgrade[/muted.bold][/muted]"
+                        f"[muted]New version available ({latest_version}). Upgrade with: [muted.bold]uv tool install --python 3.13 langrepl --upgrade[/muted.bold][/muted]"
                     )
                     console.print("")
         except Exception:

--- a/src/langrepl/utils/version.py
+++ b/src/langrepl/utils/version.py
@@ -83,7 +83,7 @@ def check_for_updates() -> tuple[str, str] | None:
             return tuple(int(x) for x in v.split("."))
 
         if parse_version(latest_version) > parse_version(current_version):
-            upgrade_command = "uv tool install langrepl --upgrade"
+            upgrade_command = "uv tool install --python 3.13 langrepl --upgrade"
             return latest_version, upgrade_command
 
         return None


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin Python to 3.13.x to fix dependency conflicts. Updated README and CLI upgrade instructions to use --python 3.13 so installs stay on 3.13 and avoid breakage with 3.14+.

<sup>Written for commit a0067044d5b31a25dcfaaaba66d21eb3d5fb0994. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

