### PR TITLE
feat: Add Moonshot AI (Kimi) LLM support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ LLM__ANTHROPIC_API_KEY=your_anthropic_api_key_here
 LLM__GOOGLE_API_KEY=your_google_api_key_here
 LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
+LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # Standard Moonshot API (China)
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global Moonshot API
+# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code API (requires subscription)
+LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
 
 # AWS Credentials (for Bedrock)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_here

--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,11 @@ LLM__ANTHROPIC_API_KEY=your_anthropic_api_key_here
 LLM__GOOGLE_API_KEY=your_google_api_key_here
 LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
+# Moonshot AI (Kimi)
+# Get your API key: https://platform.moonshot.cn
 LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # Standard Moonshot API (China)
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global Moonshot API
-# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code API (requires subscription)
-LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
+# Optional: use global endpoint instead of default China endpoint
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
 
 # AWS Credentials (for Bedrock)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_here

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://github.com/user-attachments/assets/3666d330-154c-4443-902c-8640c66a7d62
   sub-agent delegation for complex multi-step tasks
 - **LangGraph Server Mode** - Run agents as API servers with LangGraph Studio integration for visual debugging
 - **AG-UI Server Mode** - Expose agents via the [AG-UI protocol](https://docs.ag-ui.com) (SSE streaming) for frontend integration with [CopilotKit](https://www.copilotkit.ai) and other AG-UI clients
-- **Multi-Provider LLM Support** - OpenAI, Anthropic, Google, AWS Bedrock, Ollama, DeepSeek, ZhipuAI, and local models (LMStudio, Ollama)
+- **Multi-Provider LLM Support** - OpenAI, Anthropic, Google, AWS Bedrock, Ollama, DeepSeek, ZhipuAI, Moonshot AI (Kimi), and local models (LMStudio, Ollama)
 - **Multimodal Image Support** - Send images to vision models via clipboard paste, drag-and-drop, or absolute paths
 - **Extensible Tool System** - File operations, web search, terminal access, grep search, and MCP server integration
 - **[Skill System](https://github.com/anthropics/skills)** - Modular knowledge packages that extend agent capabilities with specialized workflows and domain expertise
@@ -180,6 +180,13 @@ LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 
 # Zhipu AI
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
+
+# Moonshot AI (Kimi)
+LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
+# Optional: override base URL for Kimi Code API or global endpoint
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # China (default)
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global
+# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code (subscription)
 
 # AWS Bedrock (optional, falls back to AWS CLI credentials)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_id

--- a/README.md
+++ b/README.md
@@ -183,10 +183,8 @@ LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
 
 # Moonshot AI (Kimi)
 LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
-# Optional: override base URL for Kimi Code API or global endpoint
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # China (default)
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global
-# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code (subscription)
+# Optional: use global endpoint instead of default China endpoint
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
 
 # AWS Bedrock (optional, falls back to AWS CLI credentials)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_id

--- a/resources/configs/default/llms/moonshot.yml
+++ b/resources/configs/default/llms/moonshot.yml
@@ -1,5 +1,6 @@
-# Standard Moonshot API models (api.moonshot.cn or api.moonshot.ai)
-# For Kimi Code API (api.kimi.com/coding/v1), set LLM__MOONSHOT_BASE_URL accordingly
+# Moonshot API (api.moonshot.cn) — Kimi K2.5 models
+# Note: Kimi Code API (api.kimi.com/coding/v1) is restricted to official coding agents only
+# and is NOT supported. Use the standard Moonshot API endpoint instead.
 
 - version: 1.0.0
   model: kimi-k2.5
@@ -22,13 +23,3 @@
   output_cost_per_mtok: 3.0
   extended_reasoning:
     type: enabled
-
-- version: 1.0.0
-  model: kimi-for-coding
-  alias: kimi-for-coding
-  provider: moonshot
-  max_tokens: 8192
-  temperature: 0.6
-  context_window: 256000
-  input_cost_per_mtok: 1.0
-  output_cost_per_mtok: 3.0

--- a/resources/configs/default/llms/moonshot.yml
+++ b/resources/configs/default/llms/moonshot.yml
@@ -1,0 +1,34 @@
+# Standard Moonshot API models (api.moonshot.cn or api.moonshot.ai)
+# For Kimi Code API (api.kimi.com/coding/v1), set LLM__MOONSHOT_BASE_URL accordingly
+
+- version: 1.0.0
+  model: kimi-k2.5
+  alias: kimi-k2.5
+  provider: moonshot
+  max_tokens: 8192
+  temperature: 0.6
+  context_window: 256000
+  input_cost_per_mtok: 1.0
+  output_cost_per_mtok: 3.0
+
+- version: 1.0.0
+  model: kimi-k2.5
+  alias: kimi-k2.5-thinking
+  provider: moonshot
+  max_tokens: 10000
+  temperature: 1.0
+  context_window: 256000
+  input_cost_per_mtok: 1.0
+  output_cost_per_mtok: 3.0
+  extended_reasoning:
+    type: enabled
+
+- version: 1.0.0
+  model: kimi-for-coding
+  alias: kimi-for-coding
+  provider: moonshot
+  max_tokens: 8192
+  temperature: 0.6
+  context_window: 256000
+  input_cost_per_mtok: 1.0
+  output_cost_per_mtok: 3.0

--- a/src/langrepl/configs/llm.py
+++ b/src/langrepl/configs/llm.py
@@ -26,6 +26,7 @@ class LLMProvider(str, Enum):
     BEDROCK = "bedrock"
     DEEPSEEK = "deepseek"
     ZHIPUAI = "zhipuai"
+    MOONSHOT = "moonshot"
 
 
 class RateConfig(BaseModel):

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -32,6 +32,13 @@ class LLMSettings(BaseModel):
     zhipuai_api_key: SecretStr = Field(
         default=SecretStr("dummy"), description="The Zhipu AI API key"
     )
+    moonshot_api_key: SecretStr = Field(
+        default=SecretStr("dummy"), description="The Moonshot AI API key"
+    )
+    moonshot_base_url: str = Field(
+        default="https://api.moonshot.cn/v1",
+        description="The Moonshot AI API base URL (supports standard Moonshot API, api.moonshot.ai, or Kimi Code api.kimi.com/coding/v1)",
+    )
     lmstudio_base_url: str = Field(
         default="http://localhost:1234/v1", description="The LMStudio API base URL"
     )

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -37,7 +37,7 @@ class LLMSettings(BaseModel):
     )
     moonshot_base_url: str = Field(
         default="https://api.moonshot.cn/v1",
-        description="The Moonshot AI API base URL (supports standard Moonshot API, api.moonshot.ai, or Kimi Code api.kimi.com/coding/v1)",
+        description="The Moonshot AI API base URL (supports standard Moonshot API or api.moonshot.ai)",
     )
     lmstudio_base_url: str = Field(
         default="http://localhost:1234/v1", description="The LMStudio API base URL"

--- a/src/langrepl/llms/factory.py
+++ b/src/langrepl/llms/factory.py
@@ -243,6 +243,27 @@ class LLMFactory:
                 kwargs["thinking"] = config.extended_reasoning
 
             llm = ChatZhipuAI(**kwargs)
+        elif config.provider == LLMProvider.MOONSHOT:
+            from langchain_openai import ChatOpenAI
+
+            base_url = self.llm_settings.moonshot_base_url
+            http_client, http_async_client = self._get_http_clients(base_url)
+            kwargs = {
+                "base_url": base_url,
+                "api_key": self.llm_settings.moonshot_api_key,
+                "model": config.model,
+                "max_completion_tokens": config.max_tokens,
+                "temperature": config.temperature,
+                "streaming": config.streaming,
+                "rate_limiter": limiter,
+                "http_client": http_client,
+                "http_async_client": http_async_client,
+            }
+
+            if config.extended_reasoning:
+                kwargs["reasoning"] = config.extended_reasoning
+
+            llm = ChatOpenAI(**kwargs)
         else:
             raise ValueError(f"Unknown LLM provider: {config.provider}")
 


### PR DESCRIPTION
## Summary
This PR adds support for **Moonshot AI (Kimi)** as a new LLM provider via the standard Moonshot API.

## Motivation
Moonshot AI's Kimi models (especially K2.5) are gaining popularity as capable alternatives for coding and reasoning tasks. Users have requested native integration so they can use Kimi alongside existing providers (OpenAI, Anthropic, DeepSeek, etc.) without workarounds.

## Changes

### New Provider: `moonshot`
- Added `MOONSHOT` to `LLMProvider` enum (`src/langrepl/configs/llm.py`)

### Configuration
- Added `moonshot_api_key` — API key from [platform.moonshot.cn](https://platform.moonshot.cn)
- Added `moonshot_base_url` — configurable endpoint (defaults to `https://api.moonshot.cn/v1`)

### Implementation (`src/langrepl/llms/factory.py`)
- Uses `ChatOpenAI` with custom `base_url` (OpenAI-compatible API)
- Supports two endpoints:
  - `https://api.moonshot.cn/v1` — Standard Moonshot API (China, default)
  - `https://api.moonshot.ai/v1` — Global Moonshot API
- Full support for streaming, rate limiting, proxies, and `extended_reasoning`

> **Note:** Kimi Code API (`api.kimi.com/coding/v1`) is restricted to official coding agents only and is intentionally not supported.

### Pre-configured Models (`resources/configs/default/llms/moonshot.yml`)
| Model | Alias | Features |
|-------|-------|----------|
| `kimi-k2.5` | `kimi-k2.5` | General chat, temperature 0.6 |
| `kimi-k2.5` | `kimi-k2.5-thinking` | Extended reasoning enabled |

### No New Dependencies
The implementation reuses the existing `langchain-openai` package — no additional packages required.

## Environment Setup

```bash
# .env file
LLM__MOONSHOT_API_KEY=sk-your-moonshot-api-key

# Optional: use global endpoint instead of default China endpoint
# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
```

## Usage

```bash
# Interactive chat
langrepl
❯ /llm kimi-k2.5
```

```bash
# One-shot mode
langrepl -m kimi-k2.5 "Refactor this function"
```

```bash
# With reasoning (thinking mode)
langrepl -m kimi-k2.5-thinking "Solve step by step"
```

## Files Changed

| File | Change |
|------|--------|
| `src/langrepl/configs/llm.py` | Add `MOONSHOT = "moonshot"` to `LLMProvider` enum |
| `src/langrepl/core/settings.py` | Add `moonshot_api_key` + `moonshot_base_url` |
| `src/langrepl/llms/factory.py` | Moonshot LLM via `ChatOpenAI` with custom `base_url` |
| `resources/configs/default/llms/moonshot.yml` | Pre-configured model profiles |
| `.env.example` | `LLM__MOONSHOT_API_KEY` and `LLM__MOONSHOT_BASE_URL` |
| `README.md` | Moonshot listed in providers + env vars docs |

## Checklist

- [x] Added `MOONSHOT` to `LLMProvider` enum
- [x] Added `moonshot_api_key` to `LLMSettings`
- [x] Added configurable `moonshot_base_url` (supports 2 endpoints)
- [x] Implemented LLM factory with streaming, rate limiting, proxy support
- [x] Added `extended_reasoning` / thinking mode support
- [x] Added pre-configured `moonshot.yml` with cost metadata
- [x] Updated `.env.example`
- [x] Updated `README.md`
- [x] No new dependencies (reuses `langchain-openai`)
- [x] Follows existing code patterns (LMStudio/DeepSeek style)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Moonshot AI (Kimi) as a new LLM provider via the OpenAI-compatible Moonshot API, with streaming and extended reasoning support. Users can select `kimi-k2.5` and `kimi-k2.5-thinking` using new env vars and default config.

- **New Features**
  - New `moonshot` provider using `ChatOpenAI` from `langchain-openai` with configurable `base_url`.
  - Supports streaming, rate limiting, proxies, and extended reasoning.
  - Preconfigured models: `kimi-k2.5`, `kimi-k2.5-thinking`.
  - Env vars: `LLM__MOONSHOT_API_KEY`, optional `LLM__MOONSHOT_BASE_URL` (default `https://api.moonshot.cn/v1`; supports `https://api.moonshot.ai/v1`).
  - Kimi Code API is not supported.

- **Migration**
  - Set `LLM__MOONSHOT_API_KEY`; optionally set `LLM__MOONSHOT_BASE_URL` for the global endpoint.
  - Select `kimi-k2.5` or `kimi-k2.5-thinking` in CLI or config.

<sup>Written for commit b1451257f89efa9a1e202d7c123f50f38a3c722c. Summary will update on new commits. <a href="https://cubic.dev/pr/midodimori/langrepl/pull/203?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

