### PR TITLE
feat: add Moonshot AI (Kimi) support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,9 @@ LLM__ANTHROPIC_API_KEY=your_anthropic_api_key_here
 LLM__GOOGLE_API_KEY=your_google_api_key_here
 LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
-# Moonshot AI (Kimi)
-# Get your API key: https://platform.moonshot.cn
 LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
-# Optional: use global endpoint instead of default China endpoint
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
+# Optional: for China region
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1
 
 # AWS Credentials (for Bedrock)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_here

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,11 @@ LLM__ANTHROPIC_API_KEY=your_anthropic_api_key_here
 LLM__GOOGLE_API_KEY=your_google_api_key_here
 LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
+LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # Standard Moonshot API (China)
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global Moonshot API
+# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code API (requires subscription)
+LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
 
 # AWS Credentials (for Bedrock)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_here

--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,11 @@ LLM__ANTHROPIC_API_KEY=your_anthropic_api_key_here
 LLM__GOOGLE_API_KEY=your_google_api_key_here
 LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
+# Moonshot AI (Kimi)
+# Get your API key: https://platform.moonshot.cn
 LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # Standard Moonshot API (China)
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global Moonshot API
-# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code API (requires subscription)
-LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
+# Optional: use global endpoint instead of default China endpoint
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
 
 # AWS Credentials (for Bedrock)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_here

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
 
 # Moonshot AI (Kimi)
 LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
-# Optional: use global endpoint instead of default China endpoint
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
+# Optional: for China region
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1
 
 # AWS Bedrock (optional, falls back to AWS CLI credentials)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_id

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ https://github.com/user-attachments/assets/3666d330-154c-4443-902c-8640c66a7d62
   sub-agent delegation for complex multi-step tasks
 - **LangGraph Server Mode** - Run agents as API servers with LangGraph Studio integration for visual debugging
 - **AG-UI Server Mode** - Expose agents via the [AG-UI protocol](https://docs.ag-ui.com) (SSE streaming) for frontend integration with [CopilotKit](https://www.copilotkit.ai) and other AG-UI clients
-- **Multi-Provider LLM Support** - OpenAI, Anthropic, Google, AWS Bedrock, Ollama, DeepSeek, ZhipuAI, and local models (LMStudio, Ollama)
+- **Multi-Provider LLM Support** - OpenAI, Anthropic, Google, AWS Bedrock, Ollama, DeepSeek, ZhipuAI, Moonshot AI (Kimi), and local models (LMStudio, Ollama)
 - **Multimodal Image Support** - Send images to vision models via clipboard paste, drag-and-drop, or absolute paths
 - **Extensible Tool System** - File operations, web search, terminal access, grep search, and MCP server integration
 - **[Skill System](https://github.com/anthropics/skills)** - Modular knowledge packages that extend agent capabilities with specialized workflows and domain expertise
@@ -180,6 +180,13 @@ LLM__DEEPSEEK_API_KEY=your_deepseek_api_key_here
 
 # Zhipu AI
 LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
+
+# Moonshot AI (Kimi)
+LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
+# Optional: override base URL for Kimi Code API or global endpoint
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # China (default)
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global
+# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code (subscription)
 
 # AWS Bedrock (optional, falls back to AWS CLI credentials)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_id

--- a/README.md
+++ b/README.md
@@ -183,10 +183,8 @@ LLM__ZHIPUAI_API_KEY=your_zhipuai_api_key_here
 
 # Moonshot AI (Kimi)
 LLM__MOONSHOT_API_KEY=your_moonshot_api_key_here
-# Optional: override base URL for Kimi Code API or global endpoint
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.cn/v1     # China (default)
-# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1     # Global
-# LLM__MOONSHOT_BASE_URL=https://api.kimi.com/coding/v1 # Kimi Code (subscription)
+# Optional: use global endpoint instead of default China endpoint
+# LLM__MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
 
 # AWS Bedrock (optional, falls back to AWS CLI credentials)
 LLM__AWS_ACCESS_KEY_ID=your_aws_access_key_id

--- a/resources/configs/default/llms/moonshot.yml
+++ b/resources/configs/default/llms/moonshot.yml
@@ -1,5 +1,6 @@
-# Standard Moonshot API models (api.moonshot.cn or api.moonshot.ai)
-# For Kimi Code API (api.kimi.com/coding/v1), set LLM__MOONSHOT_BASE_URL accordingly
+# Moonshot API (api.moonshot.cn) — Kimi K2.5 models
+# Note: Kimi Code API (api.kimi.com/coding/v1) is restricted to official coding agents only
+# and is NOT supported. Use the standard Moonshot API endpoint instead.
 
 - version: 1.0.0
   model: kimi-k2.5
@@ -22,13 +23,3 @@
   output_cost_per_mtok: 3.0
   extended_reasoning:
     type: enabled
-
-- version: 1.0.0
-  model: kimi-for-coding
-  alias: kimi-for-coding
-  provider: moonshot
-  max_tokens: 8192
-  temperature: 0.6
-  context_window: 256000
-  input_cost_per_mtok: 1.0
-  output_cost_per_mtok: 3.0

--- a/resources/configs/default/llms/moonshot.yml
+++ b/resources/configs/default/llms/moonshot.yml
@@ -1,0 +1,34 @@
+# Standard Moonshot API models (api.moonshot.cn or api.moonshot.ai)
+# For Kimi Code API (api.kimi.com/coding/v1), set LLM__MOONSHOT_BASE_URL accordingly
+
+- version: 1.0.0
+  model: kimi-k2.5
+  alias: kimi-k2.5
+  provider: moonshot
+  max_tokens: 8192
+  temperature: 0.6
+  context_window: 256000
+  input_cost_per_mtok: 1.0
+  output_cost_per_mtok: 3.0
+
+- version: 1.0.0
+  model: kimi-k2.5
+  alias: kimi-k2.5-thinking
+  provider: moonshot
+  max_tokens: 10000
+  temperature: 1.0
+  context_window: 256000
+  input_cost_per_mtok: 1.0
+  output_cost_per_mtok: 3.0
+  extended_reasoning:
+    type: enabled
+
+- version: 1.0.0
+  model: kimi-for-coding
+  alias: kimi-for-coding
+  provider: moonshot
+  max_tokens: 8192
+  temperature: 0.6
+  context_window: 256000
+  input_cost_per_mtok: 1.0
+  output_cost_per_mtok: 3.0

--- a/resources/configs/default/llms/moonshot.yml
+++ b/resources/configs/default/llms/moonshot.yml
@@ -1,4 +1,28 @@
 - version: 1.0.0
+  model: kimi-k2.6
+  alias: kimi-k2.6
+  provider: moonshot
+  max_tokens: 8192
+  temperature: 0.6
+  context_window: 262144
+  input_cost_per_mtok: 0.95
+  output_cost_per_mtok: 4.00
+  extended_reasoning:
+    type: disabled
+
+- version: 1.0.0
+  model: kimi-k2.6
+  alias: kimi-k2.6-thinking
+  provider: moonshot
+  max_tokens: 10000
+  temperature: 1.0
+  context_window: 262144
+  input_cost_per_mtok: 0.95
+  output_cost_per_mtok: 4.00
+  extended_reasoning:
+    type: enabled
+
+- version: 1.0.0
   model: kimi-k2.5
   alias: kimi-k2.5
   provider: moonshot

--- a/resources/configs/default/llms/moonshot.yml
+++ b/resources/configs/default/llms/moonshot.yml
@@ -1,7 +1,3 @@
-# Moonshot API (api.moonshot.cn) — Kimi K2.5 models
-# Note: Kimi Code API (api.kimi.com/coding/v1) is restricted to official coding agents only
-# and is NOT supported. Use the standard Moonshot API endpoint instead.
-
 - version: 1.0.0
   model: kimi-k2.5
   alias: kimi-k2.5
@@ -9,8 +5,10 @@
   max_tokens: 8192
   temperature: 0.6
   context_window: 256000
-  input_cost_per_mtok: 1.0
-  output_cost_per_mtok: 3.0
+  input_cost_per_mtok: 0.60
+  output_cost_per_mtok: 3.00
+  extended_reasoning:
+    type: disabled
 
 - version: 1.0.0
   model: kimi-k2.5
@@ -19,7 +17,7 @@
   max_tokens: 10000
   temperature: 1.0
   context_window: 256000
-  input_cost_per_mtok: 1.0
-  output_cost_per_mtok: 3.0
+  input_cost_per_mtok: 0.60
+  output_cost_per_mtok: 3.00
   extended_reasoning:
     type: enabled

--- a/src/langrepl/configs/llm.py
+++ b/src/langrepl/configs/llm.py
@@ -26,6 +26,7 @@ class LLMProvider(str, Enum):
     BEDROCK = "bedrock"
     DEEPSEEK = "deepseek"
     ZHIPUAI = "zhipuai"
+    MOONSHOT = "moonshot"
 
 
 class RateConfig(BaseModel):

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -32,6 +32,13 @@ class LLMSettings(BaseModel):
     zhipuai_api_key: SecretStr = Field(
         default=SecretStr("dummy"), description="The Zhipu AI API key"
     )
+    moonshot_api_key: SecretStr = Field(
+        default=SecretStr("dummy"), description="The Moonshot AI API key"
+    )
+    moonshot_base_url: str = Field(
+        default="https://api.moonshot.cn/v1",
+        description="The Moonshot AI API base URL (supports standard Moonshot API, api.moonshot.ai, or Kimi Code api.kimi.com/coding/v1)",
+    )
     lmstudio_base_url: str = Field(
         default="http://localhost:1234/v1", description="The LMStudio API base URL"
     )

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -36,8 +36,8 @@ class LLMSettings(BaseModel):
         default=SecretStr("dummy"), description="The Moonshot AI API key"
     )
     moonshot_base_url: str = Field(
-        default="https://api.moonshot.cn/v1",
-        description="The Moonshot AI API base URL (supports standard Moonshot API or api.moonshot.ai)",
+        default="https://api.moonshot.ai/v1",
+        description="The Moonshot AI API base URL",
     )
     lmstudio_base_url: str = Field(
         default="http://localhost:1234/v1", description="The LMStudio API base URL"

--- a/src/langrepl/core/settings.py
+++ b/src/langrepl/core/settings.py
@@ -37,7 +37,7 @@ class LLMSettings(BaseModel):
     )
     moonshot_base_url: str = Field(
         default="https://api.moonshot.cn/v1",
-        description="The Moonshot AI API base URL (supports standard Moonshot API, api.moonshot.ai, or Kimi Code api.kimi.com/coding/v1)",
+        description="The Moonshot AI API base URL (supports standard Moonshot API or api.moonshot.ai)",
     )
     lmstudio_base_url: str = Field(
         default="http://localhost:1234/v1", description="The LMStudio API base URL"

--- a/src/langrepl/llms/factory.py
+++ b/src/langrepl/llms/factory.py
@@ -243,6 +243,27 @@ class LLMFactory:
                 kwargs["thinking"] = config.extended_reasoning
 
             llm = ChatZhipuAI(**kwargs)
+        elif config.provider == LLMProvider.MOONSHOT:
+            from langchain_openai import ChatOpenAI
+
+            base_url = self.llm_settings.moonshot_base_url
+            http_client, http_async_client = self._get_http_clients(base_url)
+            kwargs = {
+                "base_url": base_url,
+                "api_key": self.llm_settings.moonshot_api_key,
+                "model": config.model,
+                "max_completion_tokens": config.max_tokens,
+                "temperature": config.temperature,
+                "streaming": config.streaming,
+                "rate_limiter": limiter,
+                "http_client": http_client,
+                "http_async_client": http_async_client,
+            }
+
+            if config.extended_reasoning:
+                kwargs["reasoning"] = config.extended_reasoning
+
+            llm = ChatOpenAI(**kwargs)
         else:
             raise ValueError(f"Unknown LLM provider: {config.provider}")
 

--- a/src/langrepl/llms/factory.py
+++ b/src/langrepl/llms/factory.py
@@ -244,7 +244,7 @@ class LLMFactory:
 
             llm = ChatZhipuAI(**kwargs)
         elif config.provider == LLMProvider.MOONSHOT:
-            from langchain_openai import ChatOpenAI
+            from langrepl.llms.wrappers.moonshot import ChatMoonshotAI
 
             base_url = self.llm_settings.moonshot_base_url
             http_client, http_async_client = self._get_http_clients(base_url)
@@ -261,9 +261,9 @@ class LLMFactory:
             }
 
             if config.extended_reasoning:
-                kwargs["reasoning"] = config.extended_reasoning
+                kwargs["extra_body"] = {"thinking": config.extended_reasoning}
 
-            llm = ChatOpenAI(**kwargs)
+            llm = ChatMoonshotAI(**kwargs)
         else:
             raise ValueError(f"Unknown LLM provider: {config.provider}")
 

--- a/src/langrepl/llms/wrappers/moonshot.py
+++ b/src/langrepl/llms/wrappers/moonshot.py
@@ -1,0 +1,67 @@
+"""Moonshot ChatOpenAI wrapper with reasoning content support."""
+
+from __future__ import annotations
+
+import openai
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGenerationChunk, ChatResult
+from langchain_openai import ChatOpenAI as _BaseChatOpenAI
+
+
+class ChatMoonshotAI(_BaseChatOpenAI):
+    """ChatOpenAI-compatible Moonshot client that preserves thinking text."""
+
+    @staticmethod
+    def _response_to_dict(response: dict | openai.BaseModel) -> dict:
+        if isinstance(response, dict):
+            return response
+        return response.model_dump(
+            exclude={"choices": {"__all__": {"message": {"parsed"}}}}
+        )
+
+    def _create_chat_result(
+        self,
+        response: dict | openai.BaseModel,
+        generation_info: dict | None = None,
+    ) -> ChatResult:
+        response_dict = self._response_to_dict(response)
+        result = super()._create_chat_result(response, generation_info)
+
+        for generation, choice in zip(
+            result.generations, response_dict.get("choices", []), strict=False
+        ):
+            message = generation.message
+            msg_dict = choice.get("message", {})
+            reasoning_text = msg_dict.get("reasoning_content")
+            if isinstance(message, AIMessage) and reasoning_text:
+                message.additional_kwargs = message.additional_kwargs or {}
+                message.additional_kwargs["thinking"] = {
+                    "text": reasoning_text.lstrip("\n")
+                }
+
+        return result
+
+    def _convert_chunk_to_generation_chunk(
+        self,
+        chunk: dict,
+        default_chunk_class: type,
+        base_generation_info: dict | None,
+    ) -> ChatGenerationChunk | None:
+        generation_chunk = super()._convert_chunk_to_generation_chunk(
+            chunk, default_chunk_class, base_generation_info
+        )
+        if generation_chunk is None:
+            return None
+
+        choices = chunk.get("choices", []) or chunk.get("chunk", {}).get("choices", [])
+        if not choices:
+            return generation_chunk
+
+        delta = choices[0].get("delta") or {}
+        reasoning_text = delta.get("reasoning_content")
+        message = generation_chunk.message
+        if isinstance(message, AIMessageChunk) and reasoning_text:
+            message.additional_kwargs = message.additional_kwargs or {}
+            message.additional_kwargs["thinking"] = {"text": reasoning_text}
+
+        return generation_chunk

--- a/tests/llms/test_llm_factory.py
+++ b/tests/llms/test_llm_factory.py
@@ -96,6 +96,7 @@ class TestLLMFactoryCreate:
             (LLMProvider.OPENAI, "openai_api_key", "ChatOpenAI"),
             (LLMProvider.ANTHROPIC, "anthropic_api_key", "ChatAnthropic"),
             (LLMProvider.GOOGLE, "google_api_key", "ChatGoogleGenerativeAI"),
+            (LLMProvider.MOONSHOT, "moonshot_api_key", "ChatMoonshotAI"),
         ],
     )
     def test_create_model(


### PR DESCRIPTION
Supersedes #203: https://github.com/midodimori/langrepl/pull/203

This PR carries forward the Moonshot AI (Kimi) provider work from the original PR after rebasing onto the current `main` branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Moonshot AI (Kimi) as a new LLM provider via a `ChatMoonshotAI` wrapper that preserves reasoning content, with factory, config (including Kimi 2.6), settings, docs, and tests updates.

- **New Features**
  - Added `moonshot` provider via `ChatMoonshotAI` (extends `langchain_openai.ChatOpenAI`); maps `reasoning_content` to `message.additional_kwargs.thinking` for streaming and non-streaming.
  - Integrated into LLM factory and tests; defaults added in `resources/configs/default/llms/moonshot.yml` for `kimi-k2.6`, `kimi-k2.6-thinking`, `kimi-k2.5`, and `kimi-k2.5-thinking`.
  - New settings: `moonshot_api_key`, `moonshot_base_url` (default `https://api.moonshot.ai/v1`, optional China endpoint `https://api.moonshot.cn/v1`); README and `.env.example` updated.

- **Migration**
  - Set `LLM__MOONSHOT_API_KEY`.
  - Optional: set `LLM__MOONSHOT_BASE_URL` for China region.
  - Select `kimi-k2.6`, `kimi-k2.6-thinking`, `kimi-k2.5`, or `kimi-k2.5-thinking` in your LLM config.

<sup>Written for commit ff1879a075e95917712288994ca29bd9363af010. Summary will update on new commits. <a href="https://cubic.dev/pr/midodimori/langrepl/pull/210?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

