### PR TITLE
feat: route LLM factory through init_chat_model

### DIFF
--- a/resources/features/notes.yml
+++ b/resources/features/notes.yml
@@ -1,4 +1,7 @@
 features_by_version:
+  "1.12.x":
+    - "Moonshot AI (Kimi) provider support"
+    - "Provider-specific LLM options for advanced model settings"
   "1.10.x":
     - "/model command now shows provider tabs"
     - "Fix proxy when connecting to local providers"

--- a/src/langrepl/configs/llm.py
+++ b/src/langrepl/configs/llm.py
@@ -73,6 +73,10 @@ class LLMConfig(VersionedConfig):
         default=None,
         description="Extended reasoning/thinking configuration (provider-agnostic)",
     )
+    provider_options: dict[str, Any] | None = Field(
+        default=None,
+        description="Provider-specific model constructor options",
+    )
 
     @classmethod
     def get_latest_version(cls) -> str:

--- a/src/langrepl/llms/factory.py
+++ b/src/langrepl/llms/factory.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import httpx
 from botocore.config import Config
+from langchain.chat_models import init_chat_model
 from pydantic import SecretStr
 
 from langrepl.configs import LLMConfig, LLMProvider
@@ -15,6 +17,44 @@ if TYPE_CHECKING:
     from langchain_core.language_models.chat_models import BaseChatModel
 
 _LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1"}
+_INIT_CHAT_MODEL_PROVIDERS = {
+    LLMProvider.OPENAI: "openai",
+    LLMProvider.ANTHROPIC: "anthropic",
+    LLMProvider.GOOGLE: "google_genai",
+    LLMProvider.OLLAMA: "ollama",
+    LLMProvider.BEDROCK: "bedrock",
+    LLMProvider.DEEPSEEK: "deepseek",
+}
+_PROTECTED_PROVIDER_OPTION_KEYS = {
+    "api_key",
+    "openai_api_key",
+    "anthropic_api_key",
+    "google_api_key",
+    "deepseek_api_key",
+    "zhipuai_api_key",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+    "base_url",
+    "api_base",
+    "endpoint_url",
+    "http_client",
+    "http_async_client",
+    "client",
+    "async_client",
+    "root_client",
+    "root_async_client",
+    "bedrock_client",
+    "client_kwargs",
+    "async_client_kwargs",
+    "sync_client_kwargs",
+    "openai_proxy",
+    "anthropic_proxy",
+    "proxy",
+    "proxies",
+    "config",
+    "rate_limiter",
+}
 
 
 class LLMFactory:
@@ -92,6 +132,11 @@ class LLMFactory:
 
     @staticmethod
     def _get_config_hash(config: LLMConfig) -> int:
+        provider_options = (
+            json.dumps(config.provider_options, sort_keys=True, default=repr)
+            if config.provider_options
+            else None
+        )
         return hash(
             (
                 config.provider,
@@ -100,8 +145,33 @@ class LLMFactory:
                 config.max_tokens,
                 config.streaming,
                 str(config.extended_reasoning) if config.extended_reasoning else None,
+                provider_options,
             )
         )
+
+    @staticmethod
+    def _get_provider_options(config: LLMConfig) -> dict[str, Any]:
+        options = dict(config.provider_options or {})
+
+        if config.provider == LLMProvider.OLLAMA and "response_format" in options:
+            response_format = options.pop("response_format")
+            options.setdefault("format", response_format)
+
+        protected_keys = sorted(
+            set(options).intersection(_PROTECTED_PROVIDER_OPTION_KEYS)
+        )
+        if protected_keys:
+            keys = ", ".join(protected_keys)
+            raise ValueError(
+                f"Provider options for {config.provider.value} include protected keys: {keys}"
+            )
+
+        return options
+
+    def _merge_provider_options(
+        self, config: LLMConfig, kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        return kwargs | self._get_provider_options(config)
 
     def create(self, config: LLMConfig) -> BaseChatModel:
         config_hash = self._get_config_hash(config)
@@ -111,12 +181,106 @@ class LLMFactory:
         limiter = self._create_limiter(config)
         llm: BaseChatModel
 
-        if config.provider == LLMProvider.OPENAI:
+        if config.provider in _INIT_CHAT_MODEL_PROVIDERS:
+            kwargs: dict[str, Any] = {
+                "temperature": config.temperature,
+                "rate_limiter": limiter,
+            }
+
+            if config.provider == LLMProvider.OPENAI:
+                http_client, http_async_client = self._get_http_clients()
+                kwargs.update(
+                    {
+                        "api_key": self.llm_settings.openai_api_key,
+                        "max_completion_tokens": config.max_tokens,
+                        "streaming": config.streaming,
+                        "stream_usage": True,
+                        "http_client": http_client,
+                        "http_async_client": http_async_client,
+                    }
+                )
+
+                if config.extended_reasoning:
+                    kwargs["reasoning"] = config.extended_reasoning
+                    kwargs["output_version"] = "responses/v1"
+            elif config.provider == LLMProvider.ANTHROPIC:
+                kwargs.update(
+                    {
+                        "api_key": self.llm_settings.anthropic_api_key,
+                        "max_tokens_to_sample": config.max_tokens,
+                        "streaming": config.streaming,
+                        "timeout": None,
+                        "stop": None,
+                    }
+                )
+
+                if config.extended_reasoning:
+                    kwargs["thinking"] = config.extended_reasoning
+            elif config.provider == LLMProvider.GOOGLE:
+                kwargs.update(
+                    {
+                        "api_key": self.llm_settings.google_api_key,
+                        "max_tokens": config.max_tokens,
+                        "disable_streaming": not config.streaming,
+                    }
+                )
+
+                if config.extended_reasoning:
+                    kwargs.update(config.extended_reasoning)
+            elif config.provider == LLMProvider.OLLAMA:
+                base_url = self.llm_settings.ollama_base_url
+                kwargs.update(
+                    {
+                        "base_url": base_url,
+                        "num_predict": config.max_tokens,
+                        "disable_streaming": not config.streaming,
+                        **self._get_ollama_kwargs(base_url),
+                    }
+                )
+            elif config.provider == LLMProvider.BEDROCK:
+                kwargs.update(
+                    {
+                        "aws_access_key_id": self.llm_settings.aws_access_key_id,
+                        "aws_secret_access_key": self.llm_settings.aws_secret_access_key,
+                        "aws_session_token": self.llm_settings.aws_session_token,
+                        "max_tokens": config.max_tokens,
+                        "streaming": config.streaming,
+                        "config": self._get_bedrock_config(),
+                    }
+                )
+
+                if config.extended_reasoning:
+                    kwargs["model_kwargs"] = {"thinking": config.extended_reasoning}
+            elif config.provider == LLMProvider.DEEPSEEK:
+                http_client, http_async_client = self._get_http_clients()
+                kwargs.update(
+                    {
+                        "api_key": self.llm_settings.deepseek_api_key,
+                        "max_tokens": config.max_tokens,
+                        "streaming": config.streaming,
+                        "http_client": http_client,
+                        "http_async_client": http_async_client,
+                    }
+                )
+
+                if config.extended_reasoning:
+                    kwargs["reasoning"] = config.extended_reasoning
+
+            provider = _INIT_CHAT_MODEL_PROVIDERS[config.provider]
+            llm = init_chat_model(
+                config.model,
+                model_provider=provider,
+                **self._merge_provider_options(config, kwargs),
+            )
+        elif config.provider == LLMProvider.LMSTUDIO:
             from langchain_openai import ChatOpenAI
 
-            http_client, http_async_client = self._get_http_clients()
-            kwargs = {
-                "api_key": self.llm_settings.openai_api_key,
+            base_url = self.llm_settings.lmstudio_base_url
+            provider_options = self._get_provider_options(config)
+            http_client, http_async_client = self._get_http_clients(base_url)
+            direct_kwargs: dict[str, Any] = {
+                "base_url": base_url,
+                "api_key": SecretStr("SOME_KEY"),
                 "model": config.model,
                 "max_completion_tokens": config.max_tokens,
                 "temperature": config.temperature,
@@ -125,112 +289,11 @@ class LLMFactory:
                 "http_client": http_client,
                 "http_async_client": http_async_client,
             }
-
-            if config.extended_reasoning:
-                kwargs["reasoning"] = config.extended_reasoning
-                kwargs["output_version"] = "responses/v1"
-
-            llm = ChatOpenAI(**kwargs)
-        elif config.provider == LLMProvider.ANTHROPIC:
-            from langchain_anthropic import ChatAnthropic
-
-            kwargs = {
-                "api_key": self.llm_settings.anthropic_api_key,
-                "model_name": config.model,
-                "max_tokens_to_sample": config.max_tokens,
-                "temperature": config.temperature,
-                "streaming": config.streaming,
-                "rate_limiter": limiter,
-                "timeout": None,
-                "stop": None,
-            }
-
-            if config.extended_reasoning:
-                kwargs["thinking"] = config.extended_reasoning
-
-            llm = ChatAnthropic(**kwargs)
-        elif config.provider == LLMProvider.GOOGLE:
-            from langchain_google_genai import ChatGoogleGenerativeAI
-
-            kwargs = {
-                "api_key": self.llm_settings.google_api_key.get_secret_value(),
-                "model": config.model,
-                "max_tokens": config.max_tokens,
-                "temperature": config.temperature,
-                "disable_streaming": not config.streaming,
-                "rate_limiter": limiter,
-            }
-
-            if config.extended_reasoning:
-                kwargs.update(config.extended_reasoning)
-
-            llm = ChatGoogleGenerativeAI(**kwargs)
-        elif config.provider == LLMProvider.OLLAMA:
-            from langchain_ollama import ChatOllama
-
-            base_url = self.llm_settings.ollama_base_url
-            llm = ChatOllama(
-                base_url=base_url,
-                model=config.model,
-                num_predict=config.max_tokens,
-                temperature=config.temperature,
-                disable_streaming=not config.streaming,
-                rate_limiter=limiter,
-                **self._get_ollama_kwargs(base_url),
-            )
-        elif config.provider == LLMProvider.LMSTUDIO:
-            from langchain_openai import ChatOpenAI
-
-            base_url = self.llm_settings.lmstudio_base_url
-            http_client, http_async_client = self._get_http_clients(base_url)
-            llm = ChatOpenAI(
-                base_url=base_url,
-                model=config.model,
-                max_completion_tokens=config.max_tokens,
-                temperature=config.temperature,
-                streaming=config.streaming,
-                api_key=SecretStr("SOME_KEY"),
-                rate_limiter=limiter,
-                http_client=http_client,
-                http_async_client=http_async_client,
-            )
-        elif config.provider == LLMProvider.BEDROCK:
-            from langchain_aws import ChatBedrock
-
-            kwargs = {
-                "aws_access_key_id": self.llm_settings.aws_access_key_id,
-                "aws_secret_access_key": self.llm_settings.aws_secret_access_key,
-                "aws_session_token": self.llm_settings.aws_session_token,
-                "model": config.model,
-                "max_tokens": config.max_tokens,
-                "temperature": config.temperature,
-                "streaming": config.streaming,
-                "rate_limiter": limiter,
-                "config": self._get_bedrock_config(),
-            }
-
-            if config.extended_reasoning:
-                kwargs["model_kwargs"] = {"thinking": config.extended_reasoning}
-
-            llm = ChatBedrock(**kwargs)
-        elif config.provider == LLMProvider.DEEPSEEK:
-            from langchain_deepseek import ChatDeepSeek
-
-            http_client, http_async_client = self._get_http_clients()
-            llm = ChatDeepSeek(
-                api_key=self.llm_settings.deepseek_api_key,
-                model=config.model,
-                max_tokens=config.max_tokens,
-                temperature=config.temperature,
-                streaming=config.streaming,
-                rate_limiter=limiter,
-                http_client=http_client,
-                http_async_client=http_async_client,
-            )
+            llm = ChatOpenAI(**(direct_kwargs | provider_options))
         elif config.provider == LLMProvider.ZHIPUAI:
             from langrepl.llms.wrappers.zhipuai import ChatZhipuAI
 
-            kwargs = {
+            zhipuai_kwargs: dict[str, Any] = {
                 "api_key": self.llm_settings.zhipuai_api_key.get_secret_value(),
                 "model": config.model,
                 "max_tokens": config.max_tokens,
@@ -240,15 +303,16 @@ class LLMFactory:
             }
 
             if config.extended_reasoning:
-                kwargs["thinking"] = config.extended_reasoning
+                zhipuai_kwargs["thinking"] = config.extended_reasoning
 
-            llm = ChatZhipuAI(**kwargs)
+            llm = ChatZhipuAI(**self._merge_provider_options(config, zhipuai_kwargs))
         elif config.provider == LLMProvider.MOONSHOT:
             from langrepl.llms.wrappers.moonshot import ChatMoonshotAI
 
             base_url = self.llm_settings.moonshot_base_url
+            provider_options = self._get_provider_options(config)
             http_client, http_async_client = self._get_http_clients(base_url)
-            kwargs = {
+            moonshot_kwargs: dict[str, Any] = {
                 "base_url": base_url,
                 "api_key": self.llm_settings.moonshot_api_key,
                 "model": config.model,
@@ -261,9 +325,9 @@ class LLMFactory:
             }
 
             if config.extended_reasoning:
-                kwargs["extra_body"] = {"thinking": config.extended_reasoning}
+                moonshot_kwargs["extra_body"] = {"thinking": config.extended_reasoning}
 
-            llm = ChatMoonshotAI(**kwargs)
+            llm = ChatMoonshotAI(**(moonshot_kwargs | provider_options))
         else:
             raise ValueError(f"Unknown LLM provider: {config.provider}")
 

--- a/tests/llms/test_llm_factory.py
+++ b/tests/llms/test_llm_factory.py
@@ -97,6 +97,9 @@ class TestLLMFactoryCreate:
             (LLMProvider.ANTHROPIC, "anthropic_api_key", "ChatAnthropic"),
             (LLMProvider.GOOGLE, "google_api_key", "ChatGoogleGenerativeAI"),
             (LLMProvider.MOONSHOT, "moonshot_api_key", "ChatMoonshotAI"),
+            (LLMProvider.OLLAMA, None, "ChatOllama"),
+            (LLMProvider.DEEPSEEK, "deepseek_api_key", "ChatDeepSeek"),
+            (LLMProvider.LMSTUDIO, None, "ChatOpenAI"),
         ],
     )
     def test_create_model(
@@ -107,14 +110,108 @@ class TestLLMFactoryCreate:
         api_key_field,
         expected_class,
     ):
-        settings = mock_llm_settings.model_copy(
-            update={api_key_field: SecretStr("test-key")}
-        )
+        update = {api_key_field: SecretStr("test-key")} if api_key_field else {}
+        settings = mock_llm_settings.model_copy(update=update)
         config = mock_llm_config.model_copy(update={"provider": provider})
 
         model = LLMFactory(settings).create(config)
 
         assert model.__class__.__name__ == expected_class
+
+    def test_create_openai_sets_stream_usage(self, mock_llm_settings, mock_llm_config):
+        config = mock_llm_config.model_copy(
+            update={"provider": LLMProvider.OPENAI, "model": "gpt-4o-mini"}
+        )
+
+        model = LLMFactory(mock_llm_settings).create(config)
+
+        assert model.__class__.__name__ == "ChatOpenAI"
+        assert getattr(model, "stream_usage") is True
+
+    def test_custom_openai_compatible_provider_does_not_set_stream_usage(
+        self, mock_llm_settings, mock_llm_config
+    ):
+        config = mock_llm_config.model_copy(
+            update={"provider": LLMProvider.LMSTUDIO, "model": "local-model"}
+        )
+
+        model = LLMFactory(mock_llm_settings).create(config)
+
+        assert model.__class__.__name__ == "ChatOpenAI"
+        assert getattr(model, "stream_usage") is None
+
+    def test_provider_options_are_passed_to_google(
+        self, mock_llm_settings, mock_llm_config
+    ):
+        config = mock_llm_config.model_copy(
+            update={
+                "provider": LLMProvider.GOOGLE,
+                "model": "gemini-2.5-flash",
+                "provider_options": {"api_version": "v1"},
+            }
+        )
+
+        model = LLMFactory(mock_llm_settings).create(config)
+
+        assert model.__class__.__name__ == "ChatGoogleGenerativeAI"
+        assert getattr(model, "api_version") == "v1"
+
+    def test_provider_options_are_passed_to_ollama(
+        self, mock_llm_settings, mock_llm_config
+    ):
+        config = mock_llm_config.model_copy(
+            update={
+                "provider": LLMProvider.OLLAMA,
+                "model": "llama3.2",
+                "provider_options": {"response_format": "json", "logprobs": True},
+            }
+        )
+
+        model = LLMFactory(mock_llm_settings).create(config)
+
+        assert model.__class__.__name__ == "ChatOllama"
+        assert getattr(model, "format") == "json"
+        assert getattr(model, "logprobs") is True
+
+    def test_protected_provider_options_raise_error(
+        self, mock_llm_settings, mock_llm_config
+    ):
+        config = mock_llm_config.model_copy(
+            update={
+                "provider": LLMProvider.OPENAI,
+                "model": "gpt-4o-mini",
+                "provider_options": {"api_key": "bad"},
+            }
+        )
+
+        with pytest.raises(ValueError, match="protected keys: api_key"):
+            LLMFactory(mock_llm_settings).create(config)
+
+    def test_provider_options_are_part_of_cache_identity(
+        self, mock_llm_settings, mock_llm_config
+    ):
+        factory = LLMFactory(mock_llm_settings)
+        config_v1 = mock_llm_config.model_copy(
+            update={
+                "provider": LLMProvider.GOOGLE,
+                "model": "gemini-2.5-flash",
+                "provider_options": {"api_version": "v1"},
+            }
+        )
+        config_beta = mock_llm_config.model_copy(
+            update={
+                "provider": LLMProvider.GOOGLE,
+                "model": "gemini-2.5-flash",
+                "provider_options": {"api_version": "v1beta"},
+            }
+        )
+
+        model_v1 = factory.create(config_v1)
+        model_v1_again = factory.create(config_v1)
+        model_beta = factory.create(config_beta)
+
+        assert model_v1 is model_v1_again
+        assert model_v1 is not model_beta
 
     def test_unknown_provider_raises_error(self, mock_llm_settings, mock_llm_config):
         config = mock_llm_config.model_copy(update={"provider": LLMProvider.OPENAI})


### PR DESCRIPTION
## Summary

- add optional `LLMConfig.provider_options` for provider-specific chat model kwargs
- route OpenAI, Anthropic, Google GenAI, Ollama, Bedrock, and DeepSeek through `langchain.chat_models.init_chat_model()`
- keep direct construction for LMStudio, Moonshot, and ZhipuAI custom endpoint/wrapper paths
- enable OpenAI `stream_usage=True` only for the first-party OpenAI provider
- guard factory-owned provider option keys such as auth, base URLs, HTTP clients/proxy config, and rate limiters

## Notes

`provider_options` is intentionally an escape hatch. It blocks dangerous factory-owned keys, but it does not strictly validate every provider-specific option. For example, LangChain may accept an unknown Google option into `model_kwargs` with a warning. Provider-specific allowlists can be added later if stricter validation is desired.

## Verification

- `uv run pytest tests/llms/test_llm_factory.py -q` → 20 passed
- `make lint-fix` → pyupgrade/autoflake/isort/black/mypy passed
- `make test` → 906 passed, 1 skipped, 57 deselected
- `uv lock --check` → clean
- `PYTHONWARNINGS=default uv run langrepl --help` → clean
- live Gemini smoke using `provider_options={"api_version": "v1"}` → `ChatGoogleGenerativeAI`, `api_version=v1`, response `OK`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route most chat model construction through `langchain.chat_models.init_chat_model()` and add `LLMConfig.provider_options` for passing provider-specific options. This simplifies provider setup and adds a safe escape hatch for custom kwargs.

- New Features
  - Added `LLMConfig.provider_options`; merged into model kwargs with guards against auth, base URL, HTTP client/proxy, config, and rate limiter keys.
  - OpenAI now sets `stream_usage=True` only for the first‑party `openai` provider.
  - `provider_options` participates in the LLM cache identity.
  - For Ollama, `response_format` is mapped to `format`; extended reasoning fields are forwarded when supported.

- Refactors
  - OpenAI, Anthropic, Google, Ollama, Bedrock, and DeepSeek now use `init_chat_model`; LMStudio, Moonshot, and ZhipuAI remain direct due to custom endpoints/wrappers.

<sup>Written for commit 54d1c89e58e52a5be7ef0e57a18e519141d93ae1. Summary will update on new commits. <a href="https://cubic.dev/pr/midodimori/langrepl/pull/211?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

