### PR TITLE
Fix LangGraph Studio runtime context

### DIFF
--- a/src/langrepl/cli/bootstrap/server.py
+++ b/src/langrepl/cli/bootstrap/server.py
@@ -7,8 +7,10 @@ import json
 import os
 import subprocess
 import sys
+import webbrowser
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
@@ -25,6 +27,30 @@ if TYPE_CHECKING:
     from langgraph.graph.state import CompiledStateGraph
 
 LANGREPL_ROOT = Path(__file__).resolve().parents[4]
+UNSPECIFIED_HOSTS = {"0.0.0.0", "::"}
+
+
+def _local_langgraph_url(backend_url: str) -> str:
+    """Return a browser-safe local URL for LangGraph Studio and client calls."""
+    parsed = urlparse(backend_url)
+    host = parsed.hostname or "127.0.0.1"
+    if host in UNSPECIFIED_HOSTS:
+        host = "127.0.0.1"
+
+    netloc = host
+    if parsed.port:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _studio_url(server_url: str) -> str:
+    return f"https://smith.langchain.com/studio/?baseUrl={server_url}"
+
+
+def _open_studio(server_url: str) -> None:
+    console.print("Opening Studio in your browser...")
+    console.print(f"URL: {_studio_url(server_url)}")
+    webbrowser.open(_studio_url(server_url))
 
 
 async def get_graph() -> CompiledStateGraph:
@@ -133,7 +159,7 @@ async def _upsert_assistant(
         # Search for existing assistant
         search_response = await client.post(
             f"{server_url}/assistants/search",
-            json={"query": {"name": name}},
+            json={"name": name, "graph_id": config["graph_id"], "limit": 1},
             timeout=10.0,
         )
 
@@ -167,6 +193,49 @@ async def _upsert_assistant(
         console.print("")
 
     return None, False
+
+
+async def _sync_graph_assistant_contexts(
+    client: httpx.AsyncClient, server_url: str, graph_id: str, context: dict
+) -> int:
+    """Update existing graph assistants missing required runtime context."""
+    try:
+        response = await client.post(
+            f"{server_url}/assistants/search",
+            json={"graph_id": graph_id, "limit": 100},
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        assistants = response.json()
+    except httpx.HTTPError as e:
+        console.print_error(f"Failed to search assistants for context sync: {e}")
+        console.print("")
+        return 0
+
+    updated = 0
+    required_context_keys = ("approval_mode", "working_dir")
+    for assistant in assistants:
+        existing_context = assistant.get("context") or {}
+        if all(existing_context.get(key) is not None for key in required_context_keys):
+            continue
+
+        merged_context = {**existing_context, **context}
+        try:
+            response = await client.patch(
+                f"{server_url}/assistants/{assistant['assistant_id']}",
+                json={"context": merged_context},
+                timeout=10.0,
+            )
+            response.raise_for_status()
+            updated += 1
+        except httpx.HTTPError:
+            logger.debug(
+                "Failed to sync assistant context for %s",
+                assistant.get("assistant_id"),
+                exc_info=True,
+            )
+
+    return updated
 
 
 async def _get_or_create_thread(
@@ -208,6 +277,7 @@ async def _send_message(
     assistant_id: str,
     message: str,
     resume: bool,
+    context: dict,
 ) -> tuple[int, str]:
     """Send message to LangGraph server.
 
@@ -229,6 +299,7 @@ async def _send_message(
         payload = {
             "assistant_id": assistant_id,
             "input": {"messages": [{"role": "user", "content": message}]},
+            "context": context,
         }
 
         response = await client.post(
@@ -242,6 +313,35 @@ async def _send_message(
         console.print_error(f"Failed to send message: {e}")
         console.print("")
         return 1, ""
+
+
+def _build_runtime_context(
+    approval_mode: str,
+    working_dir: Path,
+    llm_config: Any,
+) -> dict:
+    return {
+        "approval_mode": approval_mode,
+        "working_dir": str(working_dir),
+        "input_cost_per_mtok": llm_config.input_cost_per_mtok if llm_config else None,
+        "output_cost_per_mtok": (
+            llm_config.output_cost_per_mtok if llm_config else None
+        ),
+    }
+
+
+def _build_assistant_config(
+    assistant_name: str,
+    approval_mode: str,
+    working_dir: Path,
+    llm_config: Any,
+) -> dict:
+    """Build LangGraph assistant payload with runtime context values."""
+    return {
+        "graph_id": "agent",
+        "context": _build_runtime_context(approval_mode, working_dir, llm_config),
+        "name": assistant_name,
+    }
 
 
 async def _start_agui_server(args, server_config) -> int:
@@ -378,6 +478,15 @@ async def handle_server_command(args) -> int:
 
         console.print("Starting LangGraph development server...")
         config_path = working_dir / CONFIG_LANGGRAPH_FILE_NAME
+        server_url = _local_langgraph_url(server_config.backend_url)
+        parsed_server_url = urlparse(server_url)
+        if parsed_server_url.port is None:
+            console.print_error(
+                "LangGraph backend_url must include a port "
+                "(for example: http://127.0.0.1:8000)"
+            )
+            console.print("")
+            return 1
 
         python_bin = Path(sys.executable)
         langgraph_bin = python_bin.parent / "langgraph"
@@ -391,12 +500,20 @@ async def handle_server_command(args) -> int:
             return 1
 
         process = subprocess.Popen(
-            [str(langgraph_bin), "dev", "--config", str(config_path)],
+            [
+                str(langgraph_bin),
+                "dev",
+                "--config",
+                str(config_path),
+                "--no-browser",
+                "--host",
+                parsed_server_url.hostname or "127.0.0.1",
+                "--port",
+                str(parsed_server_url.port),
+            ],
             cwd=working_dir,
             env=env,
         )
-
-        server_url = server_config.backend_url
 
         async with httpx.AsyncClient() as client:
             # Wait for server to be ready
@@ -411,25 +528,26 @@ async def handle_server_command(args) -> int:
 
             # Create or update assistant
             assistant_name = f"{args.agent or agent_config.name} Assistant"
-            assistant_config = {
-                "graph_id": "agent",
-                "config": {
-                    "configurable": {
-                        "approval_mode": args.approval_mode,
-                        "working_dir": str(working_dir),
-                        "input_cost_per_mtok": (
-                            llm_config.input_cost_per_mtok if llm_config else None
-                        ),
-                        "output_cost_per_mtok": (
-                            llm_config.output_cost_per_mtok if llm_config else None
-                        ),
-                    }
-                },
-                "name": assistant_name,
-            }
+            runtime_context = _build_runtime_context(
+                args.approval_mode,
+                working_dir,
+                llm_config,
+            )
+            assistant_config = _build_assistant_config(
+                assistant_name,
+                args.approval_mode,
+                working_dir,
+                llm_config,
+            )
 
             assistant, was_updated = await _upsert_assistant(
                 client, server_url, assistant_name, assistant_config
+            )
+            synced_count = await _sync_graph_assistant_contexts(
+                client,
+                server_url,
+                "agent",
+                runtime_context,
             )
 
             if assistant:
@@ -438,6 +556,11 @@ async def handle_server_command(args) -> int:
                     f"{action} assistant: {assistant['name']} "
                     f"(ID: {assistant['assistant_id']}, Version: {assistant['version']})"
                 )
+            if synced_count:
+                console.print(
+                    f"Synchronized runtime context for {synced_count} assistant(s)"
+                )
+            _open_studio(server_url)
 
             # If message provided, send it
             if args.message and assistant:
@@ -447,6 +570,7 @@ async def handle_server_command(args) -> int:
                     assistant["assistant_id"],
                     args.message,
                     args.resume,
+                    runtime_context,
                 )
                 if exit_code == 0:
                     console.print(f"Message sent to thread: {sent_thread_id}")

--- a/tests/cli/bootstrap/test_server.py
+++ b/tests/cli/bootstrap/test_server.py
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from langrepl.cli.bootstrap.server import (
+    _local_langgraph_url,
+    _send_message,
     _set_assistant_version,
+    _sync_graph_assistant_contexts,
     _upsert_assistant,
     _wait_for_server_ready,
     generate_langgraph_json,
@@ -65,6 +68,7 @@ def patch_server_dependencies(
             return_value=mock_subprocess,
         ) as mock_popen,
         patch("langrepl.cli.bootstrap.server.httpx.AsyncClient") as mock_client_cls,
+        patch("langrepl.cli.bootstrap.server._open_studio") as mock_open_studio,
     ):
         mock_client_cls.return_value.__aenter__ = AsyncMock(
             return_value=mock_http_client
@@ -79,6 +83,7 @@ def patch_server_dependencies(
             "client_cls": mock_client_cls,
             "client": mock_http_client,
             "process": mock_subprocess,
+            "open_studio": mock_open_studio,
         }
 
 
@@ -144,6 +149,24 @@ class TestGenerateLanggraphJson:
 
         assert config_dir.exists()
         assert config_dir.is_dir()
+
+
+class TestLocalLangGraphUrl:
+    """Tests for local LangGraph URL resolution."""
+
+    def test_rewrites_unspecified_ipv4_host(self):
+        assert _local_langgraph_url("http://0.0.0.0:8000") == ("http://127.0.0.1:8000")
+
+    def test_preserves_missing_port(self):
+        assert _local_langgraph_url("http://0.0.0.0") == "http://127.0.0.1"
+
+    def test_preserves_loopback_host(self):
+        assert _local_langgraph_url("http://127.0.0.1:2024") == (
+            "http://127.0.0.1:2024"
+        )
+
+    def test_preserves_explicit_bind_host(self):
+        assert _local_langgraph_url("http://localhost:8000") == "http://localhost:8000"
 
 
 class TestGetGraph:
@@ -277,12 +300,48 @@ class TestUpsertAssistant:
         mock_client.post = mock_post
 
         assistant, was_updated = await _upsert_assistant(
-            mock_client, "http://localhost:8000", "Test Assistant", {}
+            mock_client,
+            "http://localhost:8000",
+            "Test Assistant",
+            {"graph_id": "agent"},
         )
 
         assert assistant is not None
         assert was_updated is False
         assert assistant["assistant_id"] == "new-id"
+
+    @pytest.mark.asyncio
+    @patch(
+        "langrepl.cli.bootstrap.server._set_assistant_version", new_callable=AsyncMock
+    )
+    async def test_upsert_assistant_searches_by_name_and_graph(self, _mock_set_version):
+        """Test that assistant search uses the current API payload shape."""
+        mock_client = AsyncMock()
+        mock_search_response = MagicMock()
+        mock_search_response.status_code = 200
+        mock_search_response.json = MagicMock(return_value=[])
+        mock_create_response = MagicMock()
+        mock_create_response.status_code = 200
+        mock_create_response.json = MagicMock(
+            return_value={"assistant_id": "new-id", "version": 1}
+        )
+        mock_client.post = AsyncMock(
+            side_effect=[mock_search_response, mock_create_response]
+        )
+
+        await _upsert_assistant(
+            mock_client,
+            "http://localhost:8000",
+            "Test Assistant",
+            {"graph_id": "agent"},
+        )
+
+        search_call = mock_client.post.call_args_list[0]
+        assert search_call.kwargs["json"] == {
+            "name": "Test Assistant",
+            "graph_id": "agent",
+            "limit": 1,
+        }
 
     @pytest.mark.asyncio
     async def test_upsert_assistant_updates_existing_assistant(self):
@@ -305,7 +364,10 @@ class TestUpsertAssistant:
         mock_client.patch = AsyncMock(return_value=mock_update_response)
 
         assistant, was_updated = await _upsert_assistant(
-            mock_client, "http://localhost:8000", "Test Assistant", {}
+            mock_client,
+            "http://localhost:8000",
+            "Test Assistant",
+            {"graph_id": "agent"},
         )
 
         assert assistant is not None
@@ -325,15 +387,115 @@ class TestUpsertAssistant:
         mock_client.post = mock_post
 
         assistant, was_updated = await _upsert_assistant(
-            mock_client, "http://localhost:8000", "Test Assistant", {}
+            mock_client,
+            "http://localhost:8000",
+            "Test Assistant",
+            {"graph_id": "agent"},
         )
 
         assert assistant is None
         assert was_updated is False
 
 
+class TestSyncGraphAssistantContexts:
+    """Tests for _sync_graph_assistant_contexts."""
+
+    @pytest.mark.asyncio
+    async def test_syncs_assistants_missing_context(self):
+        mock_client = AsyncMock()
+        search_response = MagicMock()
+        search_response.raise_for_status = MagicMock()
+        search_response.json.return_value = [
+            {
+                "assistant_id": "default-id",
+                "context": {},
+            },
+            {
+                "assistant_id": "configured-id",
+                "context": {
+                    "approval_mode": "semi-active",
+                    "working_dir": "/tmp/project",
+                },
+            },
+        ]
+        patch_response = MagicMock()
+        patch_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=search_response)
+        mock_client.patch = AsyncMock(return_value=patch_response)
+        context = {"approval_mode": "semi-active", "working_dir": "/tmp/project"}
+
+        count = await _sync_graph_assistant_contexts(
+            mock_client, "http://localhost:8000", "agent", context
+        )
+
+        assert count == 1
+        mock_client.post.assert_awaited_once_with(
+            "http://localhost:8000/assistants/search",
+            json={"graph_id": "agent", "limit": 100},
+            timeout=10.0,
+        )
+        mock_client.patch.assert_awaited_once_with(
+            "http://localhost:8000/assistants/default-id",
+            json={"context": context},
+            timeout=10.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_merges_existing_context(self):
+        mock_client = AsyncMock()
+        search_response = MagicMock()
+        search_response.raise_for_status = MagicMock()
+        search_response.json.return_value = [
+            {
+                "assistant_id": "default-id",
+                "context": {"custom": "value"},
+            },
+        ]
+        patch_response = MagicMock()
+        patch_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(return_value=search_response)
+        mock_client.patch = AsyncMock(return_value=patch_response)
+        context = {"approval_mode": "semi-active", "working_dir": "/tmp/project"}
+
+        count = await _sync_graph_assistant_contexts(
+            mock_client, "http://localhost:8000", "agent", context
+        )
+
+        assert count == 1
+        mock_client.patch.assert_awaited_once_with(
+            "http://localhost:8000/assistants/default-id",
+            json={"context": {"custom": "value", **context}},
+            timeout=10.0,
+        )
+
+
 class TestHandleServerCommand:
     """Tests for handle_server_command function."""
+
+    @pytest.mark.asyncio
+    async def test_send_message_passes_runtime_context(self):
+        """Test one-shot server sends include context for context_schema."""
+        mock_client = AsyncMock()
+        thread_response = MagicMock()
+        thread_response.json.return_value = {"thread_id": "thread-1"}
+        run_response = MagicMock()
+        run_response.raise_for_status = MagicMock()
+        mock_client.post = AsyncMock(side_effect=[thread_response, run_response])
+        context = {"approval_mode": "semi-active", "working_dir": "/tmp/project"}
+
+        exit_code, thread_id = await _send_message(
+            mock_client,
+            "http://localhost:8000",
+            "assistant-1",
+            "hello",
+            False,
+            context,
+        )
+
+        assert exit_code == 0
+        assert thread_id == "thread-1"
+        run_call = mock_client.post.call_args_list[1]
+        assert run_call.kwargs["json"]["context"] == context
 
     @pytest.mark.asyncio
     async def test_handle_server_command_generates_config(
@@ -352,12 +514,33 @@ class TestHandleServerCommand:
         self, mock_app_args, patch_server_dependencies
     ):
         """Test that handle_server_command starts langgraph dev subprocess."""
+        registry = patch_server_dependencies["initializer"].get_registry.return_value
+        registry.load_server.return_value.backend_url = "http://0.0.0.0:8000"
+
         await handle_server_command(mock_app_args)
 
         patch_server_dependencies["popen"].assert_called_once()
         call_args = patch_server_dependencies["popen"].call_args[0][0]
         assert any("langgraph" in str(arg) for arg in call_args)
         assert "dev" in call_args
+        assert "--no-browser" in call_args
+        assert "--host" in call_args
+        assert "--port" in call_args
+        assert call_args[call_args.index("--host") + 1] == "127.0.0.1"
+        assert call_args[call_args.index("--port") + 1] == "8000"
+
+    @pytest.mark.asyncio
+    async def test_handle_server_command_requires_backend_port(
+        self, mock_app_args, patch_server_dependencies
+    ):
+        """Test that server mode fails fast when backend_url has no port."""
+        registry = patch_server_dependencies["initializer"].get_registry.return_value
+        registry.load_server.return_value.backend_url = "http://0.0.0.0"
+
+        result = await handle_server_command(mock_app_args)
+
+        assert result == 1
+        patch_server_dependencies["popen"].assert_not_called()
 
     @pytest.mark.asyncio
     async def test_handle_server_command_sets_env_variables(


### PR DESCRIPTION
## Summary

Fix LangGraph server mode so Studio runs receive the required `AgentContext` values without weakening the context schema.

## What changed

- Normalize local LangGraph URLs so `0.0.0.0` / `::` are converted to `127.0.0.1` for client and Studio URLs.
- Launch `langgraph dev` with explicit `--host`, `--port`, and `--no-browser`.
- Open Studio only after assistant creation and runtime context sync complete.
- Store `approval_mode`, `working_dir`, and token cost values in LangGraph assistant/run `context` instead of `config.configurable`.
- Update assistant search payloads to use the current `assistants/search` shape.
- Add focused tests for URL normalization, assistant context sync, assistant config payloads, and one-shot message context.

## Root Cause

`lg -s` relied on the configured backend URL while `langgraph dev` used its own default host/port and opened Studio immediately. Studio could therefore connect to an assistant whose runtime context was still empty, causing `AgentContext` validation errors for `approval_mode` and `working_dir`. When the configured URL used `0.0.0.0`, Studio also rejected that domain.

## Validation

- `uv run pytest tests/cli/bootstrap/test_server.py`
- `uv run mypy src/langrepl/cli/bootstrap/server.py tests/cli/bootstrap/test_server.py --check-untyped-defs`
- `uv run black --check src/langrepl/cli/bootstrap/server.py tests/cli/bootstrap/test_server.py`
- Smoke-tested `uv run lg -s`; Studio opens with `baseUrl=http://127.0.0.1:8000` after context sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LangGraph Studio runs by passing the required runtime context and using a browser‑safe local URL, preventing `AgentContext` validation errors and Studio connection issues. Also enforces an explicit port on local URLs and syncs missing context for existing assistants.

- **Bug Fixes**
  - Rewrite local backend URLs: `0.0.0.0`/`::` → `127.0.0.1`; require an explicit port; use this URL for client calls and Studio `baseUrl`.
  - Start `langgraph dev` with `--host`, `--port`, `--no-browser`, and open Studio only after assistant creation and context sync.
  - Store `approval_mode`, `working_dir`, and token cost fields in assistant/run `context` instead of `config.configurable`.
  - Update `assistants/search` payload to current shape (`name`, `graph_id`, `limit`) and synchronize missing runtime context for existing assistants.
  - Include runtime `context` on one-shot message runs.

<sup>Written for commit 8b31dbbd5e941ccc64685d224799ea8d5ef4ef14. Summary will update on new commits. <a href="https://cubic.dev/pr/midodimori/langrepl/pull/214?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

